### PR TITLE
fix: Python 3.11 f-string cannot contain backslash in expression part

### DIFF
--- a/src/autoinfo/output.py
+++ b/src/autoinfo/output.py
@@ -702,7 +702,7 @@ def _build_digest_llm_prompt(entries: list[dict[str, Any]]) -> str:
 
         lines.append(f"Entry {i}:")
         lines.append(f"  Title: {title}")
-        lines.append(f"  Summary: {summary[:500] if summary else '\u2014'}")
+        lines.append(f"  Summary: {summary[:500] if summary else chr(8212)}")
         lines.append(f"  Tags: {tags_str}")
         lines.append("")
 


### PR DESCRIPTION
## Problem

`output.py:705` uses `\u2014` (em dash escape) inside an f-string expression on Python 3.11:

```python
f"  Summary: {summary[:500] if summary else '\u2014'}"
```

This causes `SyntaxError` because f-string expressions cannot contain backslashes in Python <3.12.

Discovered during v1.4 validation. Two test failures resolved after fix.

## Fix

Replace with `chr(8212)`:

```python
f"  Summary: {summary[:500] if summary else chr(8212)}"
```

## Verification

- `python3 -c "from autoinfo.output import *"` passes ✅
- Two previously failing tests now pass ✅