### PR TITLE
fix: convert SQLite dicts to KBEntry objects before dedup check

### DIFF
--- a/src/autoinfo/process.py
+++ b/src/autoinfo/process.py
@@ -514,7 +514,12 @@ def run_processing(
     kb_store = KBStore()
 
     # Load existing entries for G2 dedup checking
-    existing_entries = kb_store.list_entries(domain, limit=10000)
+    # Convert SQLite dicts back to KBEntry objects for type safety
+    from autoinfo.models import KBEntry
+    existing_entries_raw = kb_store.list_entries(domain, limit=10000)
+    existing_entries: list[KBEntry] = [
+        KBEntry(**row) for row in existing_entries_raw
+    ]
 
     # Resolve topic keywords from domain config (for G3)
     topic_keywords: list[str] = []


### PR DESCRIPTION
SQLiteIndex.list_entries() returns list[dict], but DedupChecker.check() expects list[KBEntry].
    
When dicts were passed directly, it crashed with: 'dict' object has no attribute 'source_url'

Fix: convert dicts to KBEntry objects before passing to quality gates.