### PR TITLE
fix #55: replace PEP 695 generic function syntax with TypeVar for Python 3.11 compat

### DIFF
--- a/src/autoinfo/mcp/server.py
+++ b/src/autoinfo/mcp/server.py
@@ -52,7 +52,7 @@ import sqlite3
 import uuid
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Callable, Literal
+from typing import Any, Callable, Literal, TypeVar
 
 import httpx
 from mcp.server import Server
@@ -109,7 +109,10 @@ def _job_db_path() -> Path:
     return Path.cwd() / "autoinfo.db"
 
 
-def _with_job_db[T](fn: Callable[[sqlite3.Connection], T]) -> T:
+T = TypeVar('T')
+
+
+def _with_job_db(fn: Callable[[sqlite3.Connection], T]) -> T:
     """Open a connection, call *fn*, then close.
 
     Uses the same PRAGMA settings as :class:`~autoinfo.kb.SQLiteIndex`.


### PR DESCRIPTION
## Description

`def _with_job_db[T](fn: Callable[[sqlite3.Connection], T]) -> T:` uses Python 3.12+ PEP 695 generic function syntax, but the project declares `requires-python = ">=3.11"`. This causes a `SyntaxError` on any Python 3.11 installation.

## Fix

Replace `[T]` syntax with the `TypeVar` pattern that works on Python 3.7+:

```python
T = TypeVar("T")

def _with_job_db(fn: Callable[[sqlite3.Connection], T]) -> T:
```

## Verification

```python
from autoinfo.mcp.server import app
# No SyntaxError on Python 3.11.15 ✅
```

## Related

Closes #55