### PR TITLE
fix #54, #56: remove Unpaywall from demo config, add CrossRef settings, validate empty keywords

### DIFF
--- a/src/autoinfo/cli/topics.py
+++ b/src/autoinfo/cli/topics.py
@@ -54,6 +54,9 @@ def add(
             return
 
     kw_list = [k.strip() for k in keywords.split(",") if k.strip()]
+    if not kw_list:
+        typer.echo("Error: At least one keyword is required.", err=True)
+        raise typer.Exit(code=1)
     new_topic = TopicConfig(name=name, keywords=kw_list)
     domain_cfg.topics.append(new_topic)
     save_config(config, config_path)

--- a/src/autoinfo/data/domains/medical-research/sources.yaml
+++ b/src/autoinfo/data/domains/medical-research/sources.yaml
@@ -26,14 +26,13 @@ sources:
     enabled: true
     rate_limit: 50
     api_key_optional: true
-
-  - name: Unpaywall
-    type: api
-    url: https://api.unpaywall.org/v2
-    quality_tier: 2
-    enabled: true
-    rate_limit: 100
-    api_key_optional: true
+    settings:
+      query_param: query
+      json_path: message.items
+      field_mapping:
+        id: DOI
+        title: "title[0]"
+        source_url: URL
 
 topics:
   - name: "IVF breakthroughs"


### PR DESCRIPTION
## Description

Two fixes in this PR:

### #54 — Remove Unpaywall from medical-research demo config

Unpaywall source was configured as `type: api` without any `settings` for the generic `HttpApiHandler`. Without `field_mapping`, `json_path`, or `query_param`, the handler returns malformed items (empty title, no domain) for any keyword query. The source also requires an email parameter for API access that is not configured.

Removed Unpaywall from the default demo config. Users who need it can add it manually with proper settings.

Also added proper `settings` for CrossRef (`query_param=query`, `json_path=message.items`, `field_mapping`) so keyword search works out of the box.

### #56 — Validate empty keywords in `topics add`

`autoinfo topics add --name "X" --keywords ""` silently created a topic with zero keywords. Added validation that rejects empty keyword lists with a clear error message.

Closes #54, Closes #56