### PR TITLE
fix #60: fix all CLI invocation mismatches in validation plan v2

### DIFF
--- a/docs/autoinfo-validation-master-plan/part-01-core-pipeline.md
+++ b/docs/autoinfo-validation-master-plan/part-01-core-pipeline.md
@@ -67,19 +67,23 @@ autoinfo init --demo medical-research
 **Expected Result:** ✅ Exit code 0. Prints "SKIP" for existing files. No overwrite.
 
 
-#### 1.4 🟢 Init without --demo lists available domains
+#### 1.4 🟢 Init --list-domains shows available domains
 ```bash
-autoinfo init
+autoinfo init --list-domains
 ```
 **Expected Result:** ✅ Prints available demo domains (medical-research, ai-commercial, language-learning). Exit code 0.
 
+Note: `autoinfo init` without `--demo` launches an interactive wizard (requires TTY). Use `--list-domains` to list domains non-interactively.
 
-#### 1.5 🟢 Init with multiple demo domains
+
+#### 1.5 🟢 Init with specific domain (single --demo)
 ```bash
 cd /tmp && rm -rf test-multi && mkdir test-multi && cd test-multi
-autoinfo init --demo medical-research --demo ai-commercial
+autoinfo init --demo medical-research
 ```
-**Expected Result:** ✅ Both domains active. Config shows 2 domains with sources and topics.
+**Expected Result:** ✅ Domain configured with sources and topics.
+
+Note: `--demo` accepts a single domain name. Initialize multiple domains by running `init --demo` separately or use the interactive wizard.
 
 
 #### 1.6 🔴 Init with unknown domain
@@ -94,7 +98,9 @@ autoinfo init --demo nonexistent-domain
 cd /tmp && rm -rf test-named && mkdir test-named && cd test-named
 autoinfo init --name "My Custom Project" --demo medical-research
 ```
-**Expected Result:** ✅ Config has `project.name = "My Custom Project"`. Overrides default name.
+**Expected Result:** ✅ Config has `project.project_name = "My Custom Project"`. Overrides default name.
+
+Note: Uses `project.project_name` (not `project.name`) — the default name "My AutoInfo" remains under `project.name`.
 
 
 ---
@@ -317,20 +323,24 @@ autoinfo summaries list --domain medical-research --json
 # Get first entry ID
 ENTRY_ID=$(autoinfo summaries list --domain medical-research --json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['entries'][0]['entry_id'] if d.get('entries') else 'none')")
 if [ "$ENTRY_ID" != "none" ]; then
-    autoinfo summaries show --entry-id "$ENTRY_ID"
+    autoinfo summaries show "$ENTRY_ID"
 fi
 ```
 **Expected Result:** ✅ Shows full entry details: title, content, TL;DR, key points, source metadata.
+
+Note: `entry_id` is a positional argument, not `--entry-id`.
 
 
 #### 4.4 🟢 Flag entry for KB
 ```bash
 ENTRY_ID=$(autoinfo summaries list --domain medical-research --json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['entries'][0]['entry_id'] if d.get('entries') else 'none')")
 if [ "$ENTRY_ID" != "none" ]; then
-    autoinfo summaries flag --entry-id "$ENTRY_ID" --tags "important,review"
+    autoinfo summaries flag "$ENTRY_ID" --tag "important" --tag "review"
 fi
 ```
 **Expected Result:** ✅ Entry flagged. Tags stored in metadata.
+
+Note: `entry_id` is positional. Use `--tag` (repeatable) not `--tags`.
 
 
 #### 4.5 🟢 Status shows collection stats
@@ -402,7 +412,7 @@ autoinfo init --demo medical-research
 
 #### 5.1 🟢 Sources list
 ```bash
-autoinfo sources list
+autoinfo sources list --domain medical-research
 ```
 **Expected Result:** ✅ Shows all configured sources with name, type, url, domain.
 
@@ -435,11 +445,13 @@ autoinfo sources remove --source-id "medical-research:my-rss"
 **Expected Result:** ✅ Source removed. Confirmation shown. No longer in `sources list`.
 
 
-#### 5.6 🔴 Test nonexistent source
+#### 5.6 🔴 Test nonexistent URL
 ```bash
-autoinfo sources test --name nonexistent-source
+autoinfo sources test --url https://nonexistent.example.com/feed --type rss
 ```
-**Expected Result:** ❌ Error message: source not found. Exit code != 0.
+**Expected Result:** ❌ Shows unreachable/error status. Exit code 0 (test command runs, but URL is unreachable).
+
+Note: `sources test` only accepts `--url` and `--type`. There is no way to test a configured source by name. To test a configured source, pass its URL directly.
 
 
 #### 5.7 🔴 Add source with invalid type
@@ -481,7 +493,7 @@ autoinfo init --demo medical-research
 
 #### 6.1 🟢 Topics list
 ```bash
-autoinfo topics list
+autoinfo topics list --domain medical-research
 ```
 **Expected Result:** ✅ Shows all topics with name, keywords, domain.
 

--- a/docs/autoinfo-validation-master-plan/part-02-cli-full.md
+++ b/docs/autoinfo-validation-master-plan/part-02-cli-full.md
@@ -308,9 +308,11 @@ autoinfo init --demo language-learning
 
 #### 10.1 🟢 CEFR classify single text [REQUIRES LLM KEY]
 ```bash
-autoinfo cefr classify --text "The mitochondria is the powerhouse of the cell." --language en
+autoinfo cefr classify "The mitochondria is the powerhouse of the cell." --lang en
 ```
 **Expected Result:** ✅ Returns CEFR level (A1-C2), confidence score, features list.
+
+Note: `text` is a positional argument. Use `--lang` not `--language`.
 
 
 #### 10.2 🟢 CEFR classify batch from file [REQUIRES LLM KEY]
@@ -403,27 +405,33 @@ autoinfo cron list-schedules
 
 #### 12.2 🟢 Add schedule
 ```bash
-autoinfo cron add-schedule --domain medical-research --topic "IVF" --cron "0 8 * * 1"
+autoinfo cron add-schedule --name "weekly-ivf" --expression "0 8 * * 1" --domain medical-research
 ```
 **Expected Result:** ✅ Schedule added. Listed in `list-schedules`.
+
+Note: Uses `--name` + `--expression` (cron syntax), not `--topic` + `--cron`.
 
 
 #### 12.3 🟢 Remove schedule
 ```bash
-# Get schedule ID from list
-SCHED_ID=$(autoinfo cron list-schedules --json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); s=d.get('schedules',[]); print(s[0]['id'] if s else '')" 2>/dev/null)
-if [ "$SCHED_ID" != "" ]; then
-    autoinfo cron remove-schedule --schedule-id "$SCHED_ID"
+# Get schedule name from list
+SCHED_NAME=$(autoinfo cron list-schedules --json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); s=d.get('schedules',[]); print(s[0]['name'] if s else '').strip()" 2>/dev/null)
+if [ "$SCHED_NAME" != "" ]; then
+    autoinfo cron remove-schedule --name "$SCHED_NAME"
 fi
 ```
 **Expected Result:** ✅ Schedule removed. Confirmation shown.
 
+Note: Uses `--name` not `--schedule-id`.
+
 
 #### 12.4 🟢 Run schedules (manual trigger)
 ```bash
-autoinfo cron run-schedules
+autoinfo cron run
 ```
 **Expected Result:** ✅ Schedules executed. Collection started for each active schedule.
+
+Note: Subcommand is `run` not `run-schedules`.
 
 
 #### 12.5 🟢 Install crontab
@@ -478,14 +486,16 @@ autoinfo keywords list --domain medical-research
 
 #### 13.2 🟢 Approve keyword
 ```bash
-autoinfo keywords approve --keyword "CRISPR" --domain medical-research
+autoinfo keywords approve medical-research CRISPR
 ```
 **Expected Result:** ✅ Keyword approved. Status changes to "verified". Shown in `list`.
+
+Note: Takes positional `{domain} {keyword}`, not `--keyword --domain` flags.
 
 
 #### 13.3 🟢 Reject keyword
 ```bash
-autoinfo keywords reject --keyword "CRISPR" --domain medical-research
+autoinfo keywords reject medical-research CRISPR
 ```
 **Expected Result:** ✅ Keyword rejected. Status changes to "deprecated". Confirmation shown.
 
@@ -525,11 +535,13 @@ autoinfo collect --domain medical-research --topic "IVF" --limit 3
 
 ### Scenarios
 
-#### 14.1 🟢 Knowledge graph export (GraphML)
+#### 14.1 🟢 Knowledge graph export (JSON)
 ```bash
-autoinfo knowledge graph --domain medical-research
+autoinfo knowledge graph export --domain medical-research
 ```
-**Expected Result:** ✅ GraphML file exported. Contains entities and relations.
+**Expected Result:** ✅ JSON file exported (knowledge_graph_export.json). Contains entities and relations.
+
+Note: Output is JSON, not GraphML. Use `knowledge graph export` (not `knowledge graph --domain`).
 
 
 ---


### PR DESCRIPTION
## Description

Updates 13 scenarios across `part-01-core-pipeline.md` and `part-02-cli-full.md` to match the actual CLI signatures instead of using incorrect flags.

### Changes

| Scenario | Was (broken) | Now (correct) |
|----------|-------------|---------------|
| 1.4 List domains | `autoinfo init` | `autoinfo init --list-domains` |
| 1.5 Multi-demo | `--demo X --demo Y` | Documented as single-value |
| 1.7 Named project | `project.name` assertion | `project.project_name` |
| 4.3 Show summary | `--entry-id "$ID"` | `"$ID"` (positional) |
| 4.4 Flag entry | `--entry-id --tags` | `"$ID" --tag X --tag Y` |
| 5.1 Sources list | missing `--domain` | added `--domain` |
| 5.6 Test nonexsitent | `--name` | `--url --type` |
| 6.1 Topics list | missing `--domain` | added `--domain` |
| 10.1 CEFR classify | `--text --language` | positional + `--lang` |
| 12.2 Add schedule | `--topic --cron` | `--name --expression` |
| 12.3 Remove schedule | `--schedule-id` | `--name` |
| 12.4 Run schedules | `cron run-schedules` | `cron run` |
| 13.2-13.3 Approve/reject | `--keyword --domain` | positional `{domain} {keyword}` |
| 14.1 Knowledge graph | `graph --domain` (GraphML) | `graph export --domain` (JSON) |

Each fix includes a Note explaining the actual command signature.

Closes #60