### PR TITLE
fix #73: add cross-domain coverage scenarios to validation plan

### DIFF
--- a/docs/autoinfo-validation-master-plan/part-01-core-pipeline.md
+++ b/docs/autoinfo-validation-master-plan/part-01-core-pipeline.md
@@ -519,6 +519,51 @@ autoinfo topics remove --topic-id "Nonexistent Topic" --domain medical-research
 **Expected Result:** ❌ Error: topic not found.
 
 
+
+
+## Q6b: Cross-Domain Collect — All 5 Demo Domains
+
+**User says:** "I want to collect data from all available domains to see which sources actually work."
+
+### Prerequisites
+```bash
+rm -rf /tmp/test-q6b && mkdir -p /tmp/test-q6b && cd /tmp/test-q6b
+```
+
+### Scenarios
+
+#### 6b.1 🟢 Init + collect all 5 domains — verify each produces raw data
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+ALL_PASS=true
+DOMAINS="medical-research ai-commercial financial-intelligence language-learning tech-ai-developer"
+for DOMAIN in $DOMAINS; do
+  echo "── Domain: $DOMAIN ──"
+  rm -rf "$DOMAIN" && mkdir "$DOMAIN" && cd "$DOMAIN"
+  OUTPUT=$(autoinfo init --demo "$DOMAIN" 2>&1)
+  COLLECT_OUT=$(timeout 15 autoinfo collect --domain "$DOMAIN" --limit 2 2>&1 || true)
+  echo "$COLLECT_OUT" | tail -3
+  # Check raw data files exist
+  RAW_COUNT=$(find collections/ -name "*.json" ! -name "_runs.json" 2>/dev/null | wc -l)
+  if [ "$RAW_COUNT" -gt 0 ]; then
+    echo "  ✅ PASS: $DOMAIN — $RAW_COUNT raw JSON files created"
+  else
+    echo "  ⚠️  $DOMAIN — 0 raw files (source may need API key or feed may be empty)"
+  fi
+  cd ..
+done
+echo ""
+echo "✅ Cross-domain collection complete. See per-domain results above."
+```
+**Expected Result:**
+- ✅ Each domain produces at least `init` output (config created)
+- ✅ `medical-research` produces raw JSON files from PubMed
+- ✅ `ai-commercial` produces raw JSON files from RSS feeds
+- ⚠️ Other domains may return 0 items if sources need API keys or feeds are empty
+- No scenario crashes or produces traceback for any domain
+
+
 ---
 
 ### 📊 Q6 Verdict

--- a/docs/autoinfo-validation-master-plan/part-02-cli-full.md
+++ b/docs/autoinfo-validation-master-plan/part-02-cli-full.md
@@ -391,6 +391,59 @@ autoinfo output translate --domain medical-research --target-lang zh-CN
 
 ---
 
+#### 9.11 🟢 Cross-domain output — digest + report across 3 domains
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+ALL_PASS=true
+for DOMAIN in medical-research ai-commercial language-learning; do
+  echo "── Domain: $DOMAIN ──"
+  TMPDIR="/tmp/test-q9-xd-$DOMAIN"
+  rm -rf "$TMPDIR" && mkdir -p "$TMPDIR" && cd "$TMPDIR"
+  autoinfo init --demo "$DOMAIN" > /dev/null 2>&1
+  COLLECT=$(timeout 15 autoinfo collect --domain "$DOMAIN" --limit 2 2>&1 || true)
+  RAW_COUNT=$(find collections/ -name "*.json" ! -name "_runs.json" 2>/dev/null | wc -l)
+
+  # Digest
+  DIGEST_OUT=$(autoinfo output digest --domain "$DOMAIN" --period daily 2>&1 || true)
+  echo "$DIGEST_OUT" | grep -qi "entries\|digest\|summary" \
+    && echo "  ✅ $DOMAIN digest: has content" \
+    || echo "  ⚠️  $DOMAIN digest: no entry content (may need LLM or collected data)"
+
+  # Report (JSON)
+  REPORT_OUT=$(autoinfo output report --domain "$DOMAIN" --format json 2>&1 || true)
+  echo "$REPORT_OUT" | python3 -c "
+import sys, json
+try:
+    data = json.loads(sys.stdin.read())
+    items = data.get('items', data.get('entries', []))
+    print(f'  ✅ $DOMAIN report JSON: {len(items)} items, sections={bool(data.get(\"sections\",[]))}')
+except: print('  ⚠️  $DOMAIN report: JSON parse failed (no data?)')" 2>&1 || true
+
+  # Export
+  EXPORT_OUT=$(autoinfo output export --domain "$DOMAIN" --format json 2>&1 || true)
+  echo "$EXPORT_OUT" | python3 -c "
+import sys, json
+try:
+    lines = [l for l in sys.stdin.read().split(chr(10)) if l.strip().startswith('{') or l.strip().startswith('/')]
+    if lines:
+        with open(lines[-1]) if lines[-1].startswith('/') else sys.stdin:
+            pass
+    print(f'  ✅ $DOMAIN export: valid')
+except: print('  ⚠️  $DOMAIN export: no data')" 2>&1 || true
+  cd /tmp
+done
+echo ""
+echo "✅ Cross-domain output complete"
+```
+**Expected Result:**
+- ✅ All 3 domains produce digest, report, and export outputs without crash
+- ✅ `medical-research` produces full content (has PubMed abstracts)
+- ⚠️ Other domains may produce lighter content (RSS snippets, no API keys)
+- No traceback or crash for any domain
+
+---
+
 ## Q10: CEFR Classification CLI
 
 **User says:** "I need to classify text by CEFR reading level."

--- a/docs/autoinfo-validation-master-plan/part-02-cli-full.md
+++ b/docs/autoinfo-validation-master-plan/part-02-cli-full.md
@@ -423,14 +423,23 @@ except: print('  ⚠️  $DOMAIN report: JSON parse failed (no data?)')" 2>&1 ||
   # Export
   EXPORT_OUT=$(autoinfo output export --domain "$DOMAIN" --format json 2>&1 || true)
   echo "$EXPORT_OUT" | python3 -c "
-import sys, json
+import sys, json, os
 try:
-    lines = [l for l in sys.stdin.read().split(chr(10)) if l.strip().startswith('{') or l.strip().startswith('/')]
-    if lines:
-        with open(lines[-1]) if lines[-1].startswith('/') else sys.stdin:
-            pass
-    print(f'  ✅ $DOMAIN export: valid')
-except: print('  ⚠️  $DOMAIN export: no data')" 2>&1 || true
+    lines = sys.stdin.read().strip().split(chr(10))
+    filepath = ''
+    for line in lines:
+        line = line.strip()
+        if line.endswith('.json') and ('/' in line or line.startswith('/')):
+            filepath = line
+    if filepath and os.path.isfile(filepath):
+        with open(filepath) as f:
+            data = json.load(f)
+        items = data.get('items', data.get('entries', []))
+        print(f'  ✅ $DOMAIN export: {len(items)} entries in {os.path.basename(filepath)}')
+    else:
+        print(f'  ⚠️  $DOMAIN export: file path not found in output')
+except Exception as e:
+    print(f'  ⚠️  $DOMAIN export: parse error ({e})')" 2>&1 || true
   cd /tmp
 done
 echo ""

--- a/docs/autoinfo-validation-master-plan/part-12-final-verdict.md
+++ b/docs/autoinfo-validation-master-plan/part-12-final-verdict.md
@@ -214,6 +214,36 @@
 
 ---
 
+## Domain Coverage Checklist
+
+Before signing off, confirm that the following minimum domain matrix was tested:
+
+| Domain | Init & Collect | KB Process | Digest/Report | Export |
+|--------|---------------|------------|---------------|--------|
+| medical-research | ✅ (Q2) | ✅ (Q3) | ✅ (Q9) | ✅ (Q9) |
+| ai-commercial | ⬜ (Q6b) | ⬜ | ⬜ (Q9.11) | ⬜ (Q9.11) |
+| language-learning | ⬜ (Q6b) | ⬜ | ⬜ (Q9.11) | ⬜ (Q9.11) |
+| financial-intelligence | ⬜ (Q6b) | ⬜ | ⬜ | ⬜ |
+| tech-ai-developer | ⬜ (Q6b) | ⬜ | ⬜ | ⬜ |
+
+- [ ] At least 3 domains produce non-empty raw data
+- [ ] At least 2 domains produce digest/report/export output without crash
+- [ ] Any domain with 0 items has documented reason (API key required, feed empty, etc.)
+
+## Data Format Completeness
+
+| Format Stage | medical-research | ai-commercial | language-learning |
+|-------------|-----------------|---------------|-------------------|
+| Raw cache JSON | ✅ | ⬜ | ⬜ |
+| KB 01-Raw markdown | ✅ | ⬜ | ⬜ |
+| KB 02-Draft | ✅ | ⬜ | ⬜ |
+| KB 03-Wiki | ✅ | ⬜ | ⬜ |
+| Digest output | ✅ | ⬜ | ⬜ |
+| Report output | ✅ | ⬜ | ⬜ |
+| Export output | ✅ | ⬜ | ⬜ |
+
+---
+
 ## Production Gap Checklist
 
 | Criteria | Status | Source |


### PR DESCRIPTION
## Problem

The validation plan covered all 15 parts but only exercised **2 of 5 domains**. Three domains (financial-intelligence, language-learning, tech-ai-developer) had **zero test scenarios** — every part defaulted to `--demo medical-research` and never tested other domains.

From an end-user perspective, different domains produce different data shapes (PubMed abstracts vs RSS headlines vs API data), and the plan had no way to catch domain-specific failures.

## Changes

### Part 1 — Q6b: Cross-domain collect (NEW)
Runs `init --demo <domain>` + `collect --limit 2` against all 5 demo domains:
- medical-research ✅ (PubMed produces real data)
- ai-commercial ✅ (TechCrunch RSS)
- language-learning ⚠️ (may need API keys)
- financial-intelligence ⚠️ (may need API keys)
- tech-ai-developer ⚠️ (mixed API availability)

Each domain verified to produce raw JSON cache files (or graceful empty result with reason).

### Part 2 — Q9.11: Cross-domain output (NEW)
Runs digest + report(JSON) + export across 3 domains:
- medical-research → full content expected
- ai-commercial → lighter RSS content
- language-learning → educational content

Verifies all three produce output without crash.

### Part 12 — Domain & Format sign-off criteria
Added two new sign-off checklists:

**Domain Coverage Checklist**: validates that ≥3 domains produce raw data and ≥2 produce output products.

**Data Format Completeness**: per-domain table tracking raw cache → KB 01-Raw → 02-Draft → 03-Wiki → digest → report → export across all stages.

Closes #73