### PR TITLE
fix(quality): normalize naive datetime in G2 dedup freshness (#145)

### DIFF
--- a/src/autoinfo/quality.py
+++ b/src/autoinfo/quality.py
@@ -111,11 +111,11 @@ class G0SchemaIntegrity:
             """Run validation once, return list of field errors."""
             errors: list[dict[str, object]] = []
 
-            for field in self.MANDATORY_FIELDS:
-                val = item.get(field)
+            for fname in self.MANDATORY_FIELDS:
+                val = item.get(fname)
                 if not isinstance(val, str) or not val.strip():
                     errors.append({
-                        "field": field,
+                        "field": fname,
                         "reason": "missing or empty",
                         "value": val,
                     })
@@ -903,9 +903,9 @@ class G3RelevanceScoring:
                 # Escalating context on retry
                 if attempt > 0:
                     user_content += (
-                        f"\n\nPrevious attempt failed to produce a valid "
-                        f"score (0-100). Please ensure you return ONLY a "
-                        f"single integer between 0 and 100."
+                        "\n\nPrevious attempt failed to produce a valid "
+                        "score (0-100). Please ensure you return ONLY a "
+                        "single integer between 0 and 100."
                     )
 
                 if self.llm_call is not None:
@@ -2618,13 +2618,19 @@ def llm_judge(
         f"Source: {source[:3000]}\nTarget: {target[:3000]}\n"
         "Score 0-100: faithfulness(meaning), terminology(domain terms), "
         "style(tone), readability(fluency). List issues.\n"
-        'Return JSON: {"faithfulness":int,"terminology":int,"style":int,"readability":int,"issues":[str]}'
+        'Return JSON: {"faithfulness":int,"terminology":int,"style":int,'
+        '"readability":int,"issues":[str]}'
     )
 
     try:
-        resp = _lm.completion(model=model, messages=[{"role": "user", "content": prompt}],
-                              **(dict(response_format={"type": "json_object"}) if json_mode else {}), max_tokens=1000, temperature=0.0,
-                              **(dict(timeout=timeout) if timeout is not None else {}))
+        resp = _lm.completion(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            **(dict(response_format={"type": "json_object"}) if json_mode else {}),
+            max_tokens=1000,
+            temperature=0.0,
+            **(dict(timeout=timeout) if timeout is not None else {}),
+        )
         parsed = json.loads(resp.choices[0].message.content)
     except Exception as e:
         logger.warning("llm_judge failed: %s", e)

--- a/src/autoinfo/quality.py
+++ b/src/autoinfo/quality.py
@@ -659,9 +659,15 @@ class G2Dedup:
         if not value:
             return None
         try:
-            return datetime.fromisoformat(value)
+            dt = datetime.fromisoformat(value)
         except (ValueError, TypeError):
             return None
+        # Normalize naive timestamps to UTC so comparisons (e.g. G2 freshness
+        # window: `item_dt - entry_dt`) never mix naive and aware datetimes
+        # (issue #145 — third occurrence of this class of bug).
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import pytest
-
 from autoinfo.config import QualityGateConfig
 from autoinfo.models import Item, KBEntry
 from autoinfo.quality import (
@@ -23,7 +21,6 @@ from autoinfo.quality import (
     QualityResult,
     run_quality_gates,
 )
-
 
 # ===================================================================
 # G1 — Source Authority
@@ -361,7 +358,9 @@ class TestG2Dedup:
         assert result.passed is True
         assert result.details["is_duplicate"] is False
 
-    def test_no_match_returns_correct_details(self, sample_item: Item, sample_kb_entry: KBEntry) -> None:
+    def test_no_match_returns_correct_details(
+        self, sample_item: Item, sample_kb_entry: KBEntry
+    ) -> None:
         existing = [
             KBEntry(
                 **{
@@ -400,7 +399,9 @@ class TestG2Dedup:
         assert result.details["matched_by"] == "url"
         assert result.passed is False
 
-    def test_different_urls_same_pmid_detected(self, sample_item: Item, sample_kb_entry: KBEntry) -> None:
+    def test_different_urls_same_pmid_detected(
+        self, sample_item: Item, sample_kb_entry: KBEntry
+    ) -> None:
         """Different URLs with same PMID should be caught by PMID match."""
         item = Item(
             **{
@@ -424,7 +425,9 @@ class TestG2Dedup:
         assert result.passed is False
         assert result.details["matched_by"] == "pmid"
 
-    def test_fuzzy_title_duplicate_detected(self, sample_item: Item, sample_kb_entry: KBEntry) -> None:
+    def test_fuzzy_title_duplicate_detected(
+        self, sample_item: Item, sample_kb_entry: KBEntry
+    ) -> None:
         """Similar titles (≥85% match) should be flagged as duplicates."""
         item = Item(
             **{
@@ -439,7 +442,8 @@ class TestG2Dedup:
                     **sample_kb_entry.to_dict(),
                     "source_url": "https://example.com/existing-entry",
                     # Title is almost identical — only missing "a" article
-                    "title": "Improved IVF outcomes with time-lapse embryo imaging: randomized controlled trial",
+                    "title": "Improved IVF outcomes with time-lapse embryo "
+                    "imaging: randomized controlled trial",
                 }
             )
         ]
@@ -452,7 +456,9 @@ class TestG2Dedup:
         assert result.details["matched_by"] == "fuzzy_title"
         assert result.details["similarity"] >= 0.85
 
-    def test_fuzzy_title_below_threshold_passes(self, sample_item: Item, sample_kb_entry: KBEntry) -> None:
+    def test_fuzzy_title_below_threshold_passes(
+        self, sample_item: Item, sample_kb_entry: KBEntry
+    ) -> None:
         """Dissimilar titles (< 85% match) should not trigger fuzzy dedup."""
         item = Item(
             **{
@@ -571,12 +577,20 @@ class TestG3RelevanceScoring:
         # 1/3 match = round((1/3)*100) = 33
         # With threshold=30: 33 >= 30 → passes (not flagged)
         # With threshold=40: 33 < 40 → flagged + hidden
-        result_low = g3.check(sample_item, topic_keywords=["IVF", "quantum", "computing"], threshold=30)
+        result_low = g3.check(
+            sample_item,
+            topic_keywords=["IVF", "quantum", "computing"],
+            threshold=30,
+        )
         assert result_low.score == 33.0
         assert result_low.passed is True
         assert result_low.flagged is False  # 33 >= 30
 
-        result_high = g3.check(sample_item, topic_keywords=["IVF", "quantum", "computing"], threshold=40)
+        result_high = g3.check(
+            sample_item,
+            topic_keywords=["IVF", "quantum", "computing"],
+            threshold=40,
+        )
         assert result_high.score == 33.0
         assert result_high.passed is False
         assert result_high.flagged is True  # 33 < 40

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -252,6 +252,32 @@ class TestG2Dedup:
         assert result.passed is True
         assert result.details["is_duplicate"] is False
 
+    def test_naive_item_aware_entry_no_crash(
+        self, sample_item: Item, sample_kb_entry: KBEntry
+    ) -> None:
+        """G2 freshness window must not crash on naive-vs-aware datetime (#145)."""
+        item = Item(
+            **{
+                **sample_item.to_dict(),
+                "collected_at": "2026-07-15T10:30:00",  # naive (no tz suffix)
+            }
+        )
+        existing = [
+            KBEntry(
+                **{
+                    **sample_kb_entry.to_dict(),
+                    "source_url": "https://example.com/other",  # bypass URL match
+                    "title": sample_item.title,  # force fuzzy-title path
+                }
+            )
+        ]  # collected_at stays aware ("2026-07-15T10:30:00Z")
+        g2 = G2Dedup()
+        result = g2.check(item, existing)
+
+        assert result.passed is False
+        assert result.details["is_duplicate"] is True
+        assert result.details["matched_by"] == "fuzzy_title"
+
     def test_pmid_duplicate_detected(self, sample_item: Item, sample_kb_entry: KBEntry) -> None:
         """Use different URLs so URL match doesn't fire before PMID match."""
         item = Item(


### PR DESCRIPTION
## Summary

Fixes #145 — the third occurrence of the naive-vs-aware datetime crash class.

`G2Dedup.check()` computes the freshness window with `(item_dt - entry_dt).days`
(`quality.py:616-618`). When one `collected_at` is naive (`2026-07-15T10:30:00`)
and the other aware (`2026-07-15T10:30:00Z`), Python raises
`TypeError: can't subtract offset-naive and offset-aware datetimes`.

Fix at the single point: `_parse_iso_datetime()` now normalizes naive timestamps
to UTC-aware (`dt.replace(tzinfo=timezone.utc)`), covering every call site
(item and entry timestamps) — same pattern as the earlier fixes at
`quality.py:2312-2318`.

## Verification

- RED: new `TestG2Dedup::test_naive_item_aware_entry_no_crash` crashed with
  `TypeError` before the fix (assertion: mixed naive/aware → fuzzy-title dup)
- GREEN: test passes; `tests/test_quality.py` 61/61; adjacent gates
  `test_quality_g4/g5/v1_5_quality_gates` 112 passed, 1 skipped
- ruff: 0 new errors (baseline 15 pre-existing on HEAD, untouched)
- lsp_diagnostics: clean on both changed files

## Commits

- `fix(quality): normalize naive datetime in G2 dedup freshness (#145)`

## Related

Closes #145