### PR TITLE
feat(llm): shared call_with_fallback helper protects all LLM call sites (#147)

### DIFF
--- a/src/autoinfo/cefr.py
+++ b/src/autoinfo/cefr.py
@@ -17,6 +17,8 @@ import logging
 import re
 from typing import Any
 
+from autoinfo.llm import call_with_fallback
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -97,13 +99,7 @@ def classify_text(
 
     # --- Call LLM ------------------------------------------------------------
     try:
-        import litellm  # noqa: PLC0415 — deferred import
-    except ImportError:
-        logger.error("litellm is not installed — cannot classify CEFR")
-        return {"cefr_level": "unknown", "confidence": 0.0}
-
-    try:
-        response = litellm.completion(
+        response = call_with_fallback(
             model=model,
             messages=[
                 {"role": "system", "content": system_prompt},
@@ -111,9 +107,9 @@ def classify_text(
             ],
             max_tokens=50,
             temperature=0.1,
-            api_base=base_url or None,
+            base_url=base_url or None,
             api_key=api_key or None,
-            **(dict(timeout=timeout) if timeout is not None else {}),
+            timeout=timeout,
         )
         content: str = response.choices[0].message.content  # type: ignore[union-attr]
         return _parse_level(content)

--- a/src/autoinfo/cli/keywords.py
+++ b/src/autoinfo/cli/keywords.py
@@ -18,6 +18,7 @@ import os
 import typer
 
 from autoinfo.keywords import KeywordsFile, KeywordState
+from autoinfo.llm import call_with_fallback
 
 app = typer.Typer(help="Manage per-domain keyword lifecycle")
 
@@ -194,8 +195,6 @@ def suggest(
         )
         raise typer.Exit(code=1)
 
-    import litellm  # deferred import — mirrors the MCP handler
-
     system_prompt = (
         "You are a keyword extraction assistant. Given a text, suggest "
         f"up to {limit} relevant keywords or short phrases (2-5 words) "
@@ -206,16 +205,16 @@ def suggest(
     user_prompt = f"Extract up to {limit} keywords from this text:\n\n{text}"
 
     try:
-        response = litellm.completion(
+        response = call_with_fallback(
             model=model,
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt},
             ],
-            **(dict(response_format={"type": "json_object"}) if json_mode else {}),
+            json_mode=json_mode,
             max_tokens=500,
             temperature=0.3,
-            api_base=base_url,
+            base_url=base_url,
             api_key=api_key or None,
         )
         content: str = response.choices[0].message.content or ""

--- a/src/autoinfo/llm.py
+++ b/src/autoinfo/llm.py
@@ -305,103 +305,59 @@ class LLMExtractor:
     ) -> ExtractionResult:
         """Execute the LLM completion and parse the result.
 
-        Iterates through the configured model chain (``[primary] + fallback``)
-        so that when the primary model fails a fallback model is tried next.
-        Logs a warning for each failed model and an info message when a
-        fallback is used successfully.
-
-        Raises :class:`RuntimeError` only after **all** models have failed.
-        The caller (``extract`` / ``extract_with_retry``) decides how to
-        handle that final failure.
+        Delegates the primary + fallback chain walk to
+        :func:`call_with_fallback` (issue #147 — single shared helper for
+        every LLM call path).  Raises :class:`RuntimeError` only after
+        **all** models have failed; the caller (``extract`` /
+        ``extract_with_retry``) decides how to handle that final failure.
         """
-        _litellm = self._get_litellm()
-        if _litellm is None:
-            raise RuntimeError("litellm is not available")
-
         system, user_prompt = self._build_prompt(item, schema)
 
-        models_to_try = [self._model] + [fb["model"] for fb in self._fallback_models]
-        attempted: list[str] = []
-        last_exception: Optional[Exception] = None
+        response = call_with_fallback(
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user_prompt},
+            ],
+            base_url=self._base_url,
+            max_tokens=2000,
+            temperature=0.1,
+            json_mode=self._should_use_json_mode(),
+            timeout=self._timeout,
+            config=self._config,
+        )
 
-        for model_name in models_to_try:
-            attempted.append(model_name)
+        usage: dict[str, Any] = {}
+        if hasattr(response, "usage") and response.usage is not None:
+            usage = {
+                "prompt_tokens": getattr(response.usage, "prompt_tokens", 0),
+                "completion_tokens": getattr(response.usage, "completion_tokens", 0),
+                "total_tokens": getattr(response.usage, "total_tokens", 0),
+            }
 
-            base_url = self._base_url
-            if model_name != self._model:
-                for fb in self._fallback_models:
-                    if fb["model"] == model_name and fb["base_url"]:
-                        base_url = fb["base_url"]
-                        break
+        content: str = response.choices[0].message.content  # type: ignore[union-attr]
+        parsed = self._parse_response(content)
 
-            try:
-                response = _litellm.completion(
-                    model=model_name,
-                    messages=[
-                        {"role": "system", "content": system},
-                        {"role": "user", "content": user_prompt},
-                    ],
-                    **(dict(response_format={"type": "json_object"}) if self._should_use_json_mode() else {}),
-                    max_tokens=2000,
-                    temperature=0.1,
-                    api_base=base_url or None,
-                    timeout=self._timeout,
-                )
+        custom_field_names: list[str] = []
+        if schema is not None:
+            custom_field_names = [f for f in schema if f not in DEFAULT_FIELDS]
 
-                if model_name != self._model:
-                    logger.info(
-                        "Fallback to %s succeeded after primary %s failed",
-                        model_name,
-                        self._model,
-                    )
+        custom_fields: dict[str, Any] = {}
+        for cf in custom_field_names:
+            if cf in parsed:
+                custom_fields[cf] = parsed[cf]
 
-                usage: dict[str, Any] = {}
-                if hasattr(response, "usage") and response.usage is not None:
-                    usage = {
-                        "prompt_tokens": getattr(response.usage, "prompt_tokens", 0),
-                        "completion_tokens": getattr(response.usage, "completion_tokens", 0),
-                        "total_tokens": getattr(response.usage, "total_tokens", 0),
-                    }
-
-                content: str = response.choices[0].message.content  # type: ignore[union-attr]
-                parsed = self._parse_response(content)
-
-                custom_field_names: list[str] = []
-                if schema is not None:
-                    custom_field_names = [f for f in schema if f not in DEFAULT_FIELDS]
-
-                custom_fields: dict[str, Any] = {}
-                for cf in custom_field_names:
-                    if cf in parsed:
-                        custom_fields[cf] = parsed[cf]
-
-                return ExtractionResult(
-                    item_id=item.id,
-                    title=item.title,
-                    tl_dr=parsed.get("tl_dr", ""),
-                    key_points=parsed.get("key_points", []),
-                    entities=parsed.get("entities", []),
-                    relevance_score=max(
-                        0.0, min(100.0, float(parsed.get("relevance_score", 0)))
-                    ),
-                    custom_fields=custom_fields,
-                    usage=usage,
-                )
-            except Exception as exc:
-                last_exception = exc
-                logger.warning(
-                    "LLM model %s failed (attempted %d/%d): %s",
-                    model_name,
-                    len(attempted),
-                    len(models_to_try),
-                    exc,
-                )
-
-        raise RuntimeError(
-            f"LLM extraction failed (no fallback configured): {', '.join(attempted)}"
-            if not self._fallback_models
-            else f"All models (primary + fallback) failed: {', '.join(attempted)}"
-        ) from last_exception
+        return ExtractionResult(
+            item_id=item.id,
+            title=item.title,
+            tl_dr=parsed.get("tl_dr", ""),
+            key_points=parsed.get("key_points", []),
+            entities=parsed.get("entities", []),
+            relevance_score=max(
+                0.0, min(100.0, float(parsed.get("relevance_score", 0)))
+            ),
+            custom_fields=custom_fields,
+            usage=usage,
+        )
 
     @staticmethod
     def _parse_response(content: str | None) -> dict[str, Any]:
@@ -447,3 +403,104 @@ class LLMExtractor:
 
         logger.warning("Failed to parse LLM response as JSON: %.200s", content or "")
         return {}
+
+
+def call_with_fallback(
+    messages: list[dict[str, str]],
+    *,
+    model: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    max_tokens: int = 2000,
+    temperature: float = 0.1,
+    json_mode: bool = False,
+    timeout: float | None = None,
+    config: Config | None = None,
+) -> Any:
+    """Call LiteLLM through the configured primary + fallback model chain.
+
+    Walks ``[primary] + config.llm.fallback`` — when the primary model
+    fails each configured fallback is tried in order and the first
+    successful response is returned.  Raises :class:`RuntimeError` once
+    every model has failed.
+
+    *model* overrides the config-derived primary.  *base_url* / *api_key*
+    are passed through to LiteLLM only when explicitly provided —
+    otherwise credentials resolve from the environment (``${ENV}``
+    placeholders in fallback keys are expanded).  Fallback entries always
+    come from *config* (or the on-disk config when *config* is ``None``).
+    *json_mode* adds ``response_format={"type": "json_object"}``.
+    """
+    _litellm = LLMExtractor._get_litellm()
+    if _litellm is None:
+        raise RuntimeError("litellm is not available")
+
+    if config is None:
+        config_path = get_config_path()
+        try:
+            config = load_config(config_path) if config_path is not None else Config()
+        except Exception:
+            config = Config()
+
+    provider = config.llm.provider or DEFAULT_PROVIDER
+    primary = (
+        model
+        or config.llm.resolve_model()
+        or f"{provider}/{config.llm.model or DEFAULT_MODEL}"
+    )
+
+    chain: list[dict[str, str]] = [{
+        "model": primary,
+        "base_url": base_url or "",
+        "api_key": api_key or "",
+    }]
+    for fb in config.llm.fallback:
+        fb_provider = fb.provider or provider
+        fb_full = f"{fb_provider}/{fb.model or config.llm.model or DEFAULT_MODEL}"
+        if fb_full == primary:
+            continue
+        fb_key = fb.api_key or ""
+        if fb_key.startswith("${") and fb_key.endswith("}"):
+            fb_key = os.environ.get(fb_key[2:-1], "")
+        chain.append({
+            "model": fb_full,
+            "base_url": fb.base_url or "",
+            "api_key": fb_key,
+        })
+
+    attempted: list[str] = []
+    last_exception: Optional[Exception] = None
+
+    for entry in chain:
+        attempted.append(entry["model"])
+        try:
+            response = _litellm.completion(
+                model=entry["model"],
+                messages=messages,
+                **(dict(response_format={"type": "json_object"}) if json_mode else {}),
+                max_tokens=max_tokens,
+                temperature=temperature,
+                api_base=entry["base_url"] or None,
+                api_key=entry["api_key"] or None,
+                timeout=timeout,
+            )
+            if entry["model"] != primary:
+                logger.info(
+                    "Fallback to %s succeeded after primary %s failed",
+                    entry["model"],
+                    primary,
+                )
+            return response
+        except Exception as exc:
+            last_exception = exc
+            logger.warning(
+                "LLM model %s failed (attempted %d/%d): %s",
+                entry["model"],
+                len(attempted),
+                len(chain),
+                exc,
+            )
+
+    raise RuntimeError(
+        f"All LLM models (primary + fallback) failed: {', '.join(attempted)}"
+    ) from last_exception

--- a/src/autoinfo/llm.py
+++ b/src/autoinfo/llm.py
@@ -503,4 +503,5 @@ def call_with_fallback(
 
     raise RuntimeError(
         f"All LLM models (primary + fallback) failed: {', '.join(attempted)}"
+        f" — last error: {last_exception}"
     ) from last_exception

--- a/src/autoinfo/mcp/server.py
+++ b/src/autoinfo/mcp/server.py
@@ -65,6 +65,7 @@ from autoinfo import __version__
 from autoinfo.cli.doctor import calculate_health_score
 from autoinfo.cli.init import _list_demo_domains
 from autoinfo.config import SOURCE_KEY_ENV_VARS, VALID_SOURCE_TYPES
+from autoinfo.llm import call_with_fallback
 from autoinfo.mcp.errors import ErrorCode, error_dict, error_response, success_response
 
 logger = logging.getLogger(__name__)
@@ -1528,8 +1529,8 @@ def _handle_remove_source(source_id: str, confirm: bool = True) -> dict[str, Any
         return {
             "error_code": ErrorCode.CONFIRMATION_REQUIRED.value,
             "message": (
-                f"This operation is destructive and requires confirmation. "
-                f"Pass confirm=True to proceed."
+                "This operation is destructive and requires confirmation. "
+                "Pass confirm=True to proceed."
             ),
             "actionable": True,
         }
@@ -1745,8 +1746,8 @@ def _handle_remove_topic(domain: str, topic_id: str, confirm: bool = True) -> di
         return {
             "error_code": ErrorCode.CONFIRMATION_REQUIRED.value,
             "message": (
-                f"This operation is destructive and requires confirmation. "
-                f"Pass confirm=True to proceed."
+                "This operation is destructive and requires confirmation. "
+                "Pass confirm=True to proceed."
             ),
             "actionable": True,
         }
@@ -2017,8 +2018,6 @@ def _handle_suggest_keywords(
     """Use LLM to suggest keywords from the given text."""
     import json
 
-    import litellm  # noqa: PLC0415 — deferred import
-
     from autoinfo.config import get_config_path, load_config
 
     timeout: float | None = None
@@ -2063,18 +2062,18 @@ def _handle_suggest_keywords(
     user_prompt = f"Extract up to {limit} keywords from this text:\n\n{text}"
 
     try:
-        response = litellm.completion(
+        response = call_with_fallback(
             model=model,
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt},
             ],
-            **(dict(response_format={"type": "json_object"}) if json_mode else {}),
+            json_mode=json_mode,
             max_tokens=500,
             temperature=0.3,
-            api_base=base_url,
+            base_url=base_url,
             api_key=api_key or None,
-            **(dict(timeout=timeout) if timeout is not None else {}),
+            timeout=timeout,
         )
         content: str = response.choices[0].message.content or ""  # type: ignore[union-attr]
 
@@ -2552,8 +2551,8 @@ def _handle_list_output_templates(domain: str = "", user_id: str | None = None) 
     whose ``access_level`` is accessible to the user are returned.
     When *user_id* is ``None``, all templates are returned (backward compatible).
     """
-    from autoinfo.output import list_output_templates as _list_output_templates
     from autoinfo.billing import check_access
+    from autoinfo.output import list_output_templates as _list_output_templates
 
     result = _list_output_templates(domain=domain)
     templates: list[dict[str, Any]] = result["templates"]
@@ -2666,10 +2665,10 @@ def _handle_generate_digest(
 
     Dispatches to :func:`autoinfo.output.generate_digest`.
     """
-    from autoinfo.output import generate_digest as _generate_digest
+    from datetime import date, timedelta
 
     from autoinfo.kb import KBStore
-    from datetime import date, timedelta
+    from autoinfo.output import generate_digest as _generate_digest
 
     _period_days = {"daily": 1, "weekly": 7, "monthly": 30}
     _days = _period_days.get(period, 7)
@@ -2761,10 +2760,10 @@ def _handle_generate_report(
 
     Dispatches to :func:`autoinfo.output.generate_report`.
     """
-    from autoinfo.output import generate_report as _generate_report
+    from datetime import date, timedelta
 
     from autoinfo.kb import KBStore
-    from datetime import date, timedelta
+    from autoinfo.output import generate_report as _generate_report
 
     _period_days = {"daily": 1, "weekly": 7, "monthly": 30}
     _days = _period_days.get(period, 7)
@@ -3407,8 +3406,8 @@ def _handle_remove_schedule(name: str, confirm: bool = False) -> dict[str, Any]:
         return {
             "error_code": ErrorCode.CONFIRMATION_REQUIRED.value,
             "message": (
-                f"This operation is destructive and requires confirmation. "
-                f"Pass confirm=True to proceed."
+                "This operation is destructive and requires confirmation. "
+                "Pass confirm=True to proceed."
             ),
             "actionable": True,
         }
@@ -3772,7 +3771,7 @@ def _handle_init_project(
     """
     # Lazy imports to avoid circular dependencies
     from autoinfo.cli.init import _DEMO_DOMAINS_DIR, _ensure_dir, _run_init
-    from autoinfo.mcp.errors import ErrorCode, error_dict
+    from autoinfo.mcp.errors import ErrorCode
 
     autoinfo_dir = Path.cwd() / ".autoinfo"
     config_path = autoinfo_dir / "config.yaml"
@@ -4114,8 +4113,8 @@ def _handle_archive_project(reason: str = "", confirm: bool = False) -> dict[str
         return {
             "error_code": ErrorCode.CONFIRMATION_REQUIRED.value,
             "message": (
-                f"This operation is destructive and requires confirmation. "
-                f"Pass confirm=True to proceed."
+                "This operation is destructive and requires confirmation. "
+                "Pass confirm=True to proceed."
             ),
             "actionable": True,
         }
@@ -4161,10 +4160,10 @@ def _handle_batch_run(
     model: str = "",
 ) -> dict[str, Any]:
     """Run collect + process in sequence for a domain. Returns per-phase results."""
+    from datetime import datetime, timezone
+
     from autoinfo.collect import run_collection
     from autoinfo.process import ProcessResult, run_processing
-
-    from datetime import datetime, timezone
 
     start_time = datetime.now(timezone.utc)
     phases: list[dict[str, Any]] = []
@@ -5140,7 +5139,8 @@ def _handle_get_metrics(name: str, arguments: dict) -> dict[str, Any]:
 
 def _handle_get_prometheus_metrics(name: str, arguments: dict) -> dict[str, Any]:
     """Return raw Prometheus exposition-format metrics in a dict wrapper."""
-    from autoinfo.metrics import format_prometheus, get_metrics as _get_metrics
+    from autoinfo.metrics import format_prometheus
+    from autoinfo.metrics import get_metrics as _get_metrics
 
     data = _get_metrics()
     return {"format": "prometheus", "metrics_text": format_prometheus(data)}
@@ -5193,6 +5193,7 @@ def _handle_delete_user_data(name: str, arguments: dict) -> dict[str, Any]:
 
 def _handle_query_delivery_log(name: str, arguments: dict) -> dict[str, Any] | list[dict[str, Any]]:
     import dataclasses
+
     from autoinfo.delivery_log import query_delivery_log
     subscription_id = arguments.get("subscription_id")
     limit = arguments.get("limit", 50)

--- a/src/autoinfo/mcp/validation.py
+++ b/src/autoinfo/mcp/validation.py
@@ -23,6 +23,8 @@ from typing import Any, Awaitable, Callable
 
 import yaml
 
+from autoinfo.llm import call_with_fallback
+
 SCENARIOS_DIR: Path = Path(__file__).resolve().parent / "scenarios"
 
 # ---------------------------------------------------------------------------
@@ -361,8 +363,6 @@ def _llm_judge(assertion: str, tool_output: Any) -> dict[str, Any]:
     ValueError
         If the judge response cannot be parsed.
     """
-    import litellm  # noqa: PLC0415 — deferred import (same as llm.py)
-
     llm_cfg = _resolve_llm_config()
     prompt = (
         "You are a validation judge for the AutoInfo platform. Determine "
@@ -373,12 +373,12 @@ def _llm_judge(assertion: str, tool_output: Any) -> dict[str, Any]:
         '"reason": "one-sentence justification"}'
     )
     start = time.monotonic()
-    response = litellm.completion(
-        model=llm_cfg["model"],
+    response = call_with_fallback(
         messages=[{"role": "user", "content": prompt}],
+        model=llm_cfg["model"],
         max_tokens=500,
         temperature=0.0,
-        api_base=llm_cfg["api_base"],
+        base_url=llm_cfg["api_base"],
         api_key=llm_cfg["api_key"] or None,
     )
     duration = time.monotonic() - start

--- a/src/autoinfo/output/__init__.py
+++ b/src/autoinfo/output/__init__.py
@@ -29,13 +29,14 @@ import sqlite3
 import tarfile
 import uuid
 import xml.etree.ElementTree as ET
-import yaml
 import zipfile
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
 from email.utils import format_datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal
+
+import yaml
 
 if TYPE_CHECKING:
     from autoinfo.config import SourceConfig  # noqa: F811
@@ -47,6 +48,7 @@ from jinja2 import ChoiceLoader, Environment, FileSystemLoader, Template, Templa
 
 from autoinfo.config import Config, get_config_path, load_config
 from autoinfo.kb import KBStore, SQLiteIndex
+from autoinfo.llm import call_with_fallback
 
 logger = logging.getLogger(__name__)
 
@@ -2231,12 +2233,6 @@ def _call_llm_for_digest(
     Uses the same LiteLLM pattern as :class:`LLMExtractor` but with
     a custom summarization prompt.
     """
-    try:
-        import litellm  # noqa: PLC0415
-    except (ImportError, ModuleNotFoundError):
-        logger.error("litellm is not installed \u2014 run 'pip install litellm'")
-        return {}
-
     if config is None:
         config_path = get_config_path()
         if config_path is not None:
@@ -2251,17 +2247,17 @@ def _call_llm_for_digest(
     full_model = model
 
     try:
-        response = litellm.completion(
+        response = call_with_fallback(
             model=full_model,
             messages=[
                 {"role": "system", "content": _DIGEST_SYSTEM_PROMPT},
                 {"role": "user", "content": prompt},
             ],
-            **(dict(response_format={"type": "json_object"}) if config.llm.json_mode and not config.llm.reasoning_model else {}),
+            json_mode=config.llm.json_mode and not config.llm.reasoning_model,
             max_tokens=4000,
             temperature=0.1,
             api_key=config.llm.api_key or None,
-            api_base=config.llm.base_url or None,
+            base_url=config.llm.base_url or None,
         )
     except Exception as exc:
         logger.error("LLM digest synthesis failed: %s", exc)
@@ -4067,12 +4063,6 @@ def _call_llm_for_translation(
     Returns a dict with ``translated_title`` and ``translated_body``.
     Returns empty strings on failure.
     """
-    try:
-        import litellm  # noqa: PLC0415
-    except (ImportError, ModuleNotFoundError):
-        logger.error("litellm is not installed — run 'pip install litellm'")
-        return {"translated_title": "", "translated_body": ""}
-
     if config is None:
         config_path = get_config_path()
         if config_path is not None:
@@ -4094,17 +4084,17 @@ def _call_llm_for_translation(
     )
 
     try:
-        response = litellm.completion(
+        response = call_with_fallback(
             model=full_model,
             messages=[
                 {"role": "system", "content": _TRANSLATION_SYSTEM_PROMPT},
                 {"role": "user", "content": user_prompt},
             ],
-            **(dict(response_format={"type": "json_object"}) if config.llm.json_mode and not config.llm.reasoning_model else {}),
+            json_mode=config.llm.json_mode and not config.llm.reasoning_model,
             max_tokens=4000,
             temperature=0.1,
             api_key=config.llm.api_key or None,
-            api_base=config.llm.base_url or None,
+            base_url=config.llm.base_url or None,
         )
     except Exception as exc:
         logger.error("LLM translation failed: %s", exc)
@@ -4661,12 +4651,6 @@ def _call_llm_for_tutorial(prompt: str) -> dict[str, Any]:
 
     Uses the same pattern as ``_call_llm_for_digest``.
     """
-    try:
-        import litellm  # noqa: PLC0415
-    except (ImportError, ModuleNotFoundError):
-        logger.error("litellm is not installed — run 'pip install litellm'")
-        return {}
-
     config_path = get_config_path()
     if config_path and config_path.is_file():
         try:
@@ -4680,7 +4664,7 @@ def _call_llm_for_tutorial(prompt: str) -> dict[str, Any]:
     full_model = model
 
     try:
-        response = litellm.completion(
+        response = call_with_fallback(
             model=full_model,
             messages=[
                 {
@@ -4691,11 +4675,11 @@ def _call_llm_for_tutorial(prompt: str) -> dict[str, Any]:
                 },
                 {"role": "user", "content": prompt},
             ],
-            **(dict(response_format={"type": "json_object"}) if config.llm.json_mode and not config.llm.reasoning_model else {}),
+            json_mode=config.llm.json_mode and not config.llm.reasoning_model,
             max_tokens=4000,
             temperature=0.1,
             api_key=config.llm.api_key or None,
-            api_base=config.llm.base_url or None,
+            base_url=config.llm.base_url or None,
         )
     except Exception as exc:
         logger.error("Tutorial generation failed: %s", exc)
@@ -4922,12 +4906,6 @@ def _render_presentation_agent_json(
 
 def _call_llm_for_presentation(prompt: str, slide_count: int) -> dict[str, Any]:
     """Call LiteLLM to generate structured presentation content."""
-    try:
-        import litellm  # noqa: PLC0415
-    except (ImportError, ModuleNotFoundError):
-        logger.error("litellm is not installed — run 'pip install litellm'")
-        return {}
-
     config_path = get_config_path()
     if config_path and config_path.is_file():
         try:
@@ -4941,7 +4919,7 @@ def _call_llm_for_presentation(prompt: str, slide_count: int) -> dict[str, Any]:
     full_model = model
 
     try:
-        response = litellm.completion(
+        response = call_with_fallback(
             model=full_model,
             messages=[
                 {
@@ -4952,11 +4930,11 @@ def _call_llm_for_presentation(prompt: str, slide_count: int) -> dict[str, Any]:
                 },
                 {"role": "user", "content": prompt},
             ],
-            **(dict(response_format={"type": "json_object"}) if config.llm.json_mode and not config.llm.reasoning_model else {}),
+            json_mode=config.llm.json_mode and not config.llm.reasoning_model,
             max_tokens=4000,
             temperature=0.1,
             api_key=config.llm.api_key or None,
-            api_base=config.llm.base_url or None,
+            base_url=config.llm.base_url or None,
         )
     except Exception as exc:
         logger.error("LLM presentation synthesis failed: %s", exc)
@@ -5015,7 +4993,7 @@ def _render_presentation_mkslides(context: dict[str, Any]) -> str:
     back to the standalone HTML renderer with a log warning.
     """
     import subprocess  # noqa: PLC0415
-    import tempfile    # noqa: PLC0415
+    import tempfile  # noqa: PLC0415
 
     title = context.get("title", "Presentation")
     author = context.get("domain", "AutoInfo")
@@ -5478,6 +5456,7 @@ def _render_audio_edge_tts(
         If the TTS synthesis fails.
     """
     import asyncio  # noqa: PLC0415
+
     import edge_tts  # noqa: PLC0415
 
     async def _synthesize() -> bytes:
@@ -5869,18 +5848,6 @@ def simplify_text(
         "Rewrite this text at the target CEFR level. Return only the simplified text."
     )
 
-    try:
-        import litellm  # noqa: PLC0415
-    except ImportError:
-        logger.error("litellm is not installed — cannot simplify content")
-        return {
-            "simplified": content,
-            "original_level": original_level,
-            "simplified_level": "unknown",
-            "verified": False,
-            "error": "litellm not installed",
-        }
-
     # Resolve model config (same pattern as cefr.py)
     from autoinfo.config import get_config_path, load_config  # noqa: PLC0415
 
@@ -5900,7 +5867,7 @@ def simplify_text(
         logger.debug("Could not load config for simplify_text", exc_info=True)
 
     try:
-        response = litellm.completion(
+        response = call_with_fallback(
             model=model,
             messages=[
                 {"role": "system", "content": system_prompt},
@@ -5909,7 +5876,7 @@ def simplify_text(
             max_tokens=4000,
             temperature=0.3,
             api_key=api_key or None,
-            api_base=base_url or None,
+            base_url=base_url or None,
         )
         simplified: str = (response.choices[0].message.content or "").strip()  # type: ignore[union-attr]
     except Exception as exc:

--- a/src/autoinfo/qa.py
+++ b/src/autoinfo/qa.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from autoinfo.config import get_config_path, load_config
 from autoinfo.kb import KBStore
+from autoinfo.llm import call_with_fallback
 
 logger = logging.getLogger(__name__)
 
@@ -144,13 +145,6 @@ def _call_llm_for_qa(query: str, articles: list[str]) -> str:
     str
         The LLM's answer text, or an error message if the call fails.
     """
-    _litellm = _get_litellm()
-    if _litellm is None:
-        return (
-            "LLM is not available. Please ensure litellm is installed "
-            "(``pip install litellm``)."
-        )
-
     # Resolve the effective model + configure API key from config
     full_model = _resolve_model()
 
@@ -172,7 +166,7 @@ def _call_llm_for_qa(query: str, articles: list[str]) -> str:
     )
 
     try:
-        response = _litellm.completion(
+        response = call_with_fallback(
             model=full_model,
             messages=[
                 {"role": "system", "content": system_prompt},
@@ -189,20 +183,6 @@ def _call_llm_for_qa(query: str, articles: list[str]) -> str:
             f"An error occurred while contacting the LLM: {exc}. "
             "Please check your LLM configuration and try again."
         )
-
-
-def _get_litellm() -> Any:
-    """Lazily import and return the ``litellm`` module.
-
-    Returns ``None`` when the package is not available.
-    """
-    try:
-        import litellm  # noqa: PLC0415 — deferred import
-
-        return litellm
-    except (ImportError, ModuleNotFoundError):
-        logger.error("litellm is not installed — run 'pip install litellm'")
-        return None
 
 
 def _resolve_model() -> str:

--- a/src/autoinfo/quality.py
+++ b/src/autoinfo/quality.py
@@ -25,6 +25,7 @@ from typing import Any, Literal
 import yaml
 
 from autoinfo.config import QualityGateConfig
+from autoinfo.llm import call_with_fallback
 from autoinfo.models import ExtractionResult, Item, KBEntry
 
 logger = logging.getLogger(__name__)
@@ -797,10 +798,9 @@ class G3RelevanceScoring:
         # ---- Choose scoring method --------------------------------------
         llm_retries_used = 0
         if gate_config is not None and gate_config.retries > 0:
-            _litellm_mod = self._get_litellm()
-            if _litellm_mod is not None and self._model:
+            if self._model:
                 score_val, llm_retries_used = self._llm_score(
-                    text, keywords, gate_config, _litellm_mod,
+                    text, keywords, gate_config,
                 )
                 if score_val is None:
                     # All retries exhausted → neutral pass
@@ -868,7 +868,6 @@ class G3RelevanceScoring:
         text: str,
         keywords: list[str],
         gate_config: QualityGateConfig,
-        litellm_mod: Any,
     ) -> tuple[int | None, int]:
         """Run LLM-based relevance scoring with retry loop.
 
@@ -920,7 +919,7 @@ class G3RelevanceScoring:
                     )
                     raw: str = response.choices[0].message.content
                 else:
-                    response = litellm_mod.completion(
+                    response = call_with_fallback(
                         model=model,
                         messages=[
                             {"role": "system", "content": self.SYSTEM_PROMPT},
@@ -928,7 +927,7 @@ class G3RelevanceScoring:
                         ],
                         max_tokens=10,
                         temperature=0.0,
-                        **(dict(timeout=self._timeout) if self._timeout is not None else {}),
+                        timeout=self._timeout,
                     )
                     raw = response.choices[0].message.content
 
@@ -1121,18 +1120,6 @@ class G4FactualConsistency:
                 },
             )
 
-        _litellm = self._get_litellm()
-        if _litellm is None:
-            return QualityResult(
-                gate_name="G4-SummaryFactual",
-                passed=False,
-                flagged=True,
-                details={
-                    "contradiction": None,
-                    "explanation": "litellm is not available",
-                },
-            )
-
         if gate_config is not None and gate_config.retries > 0:
             retry_models = list(gate_config.retry_models) if gate_config.retry_models else []
             models = [self._model] + retry_models
@@ -1163,16 +1150,16 @@ class G4FactualConsistency:
                             f"Please re-evaluate carefully."
                         )
 
-                response = _litellm.completion(
+                response = call_with_fallback(
                     model=model,
                     messages=[
                         {"role": "system", "content": self.SYSTEM_PROMPT},
                         {"role": "user", "content": user_content},
                     ],
-                    **(dict(response_format={"type": "json_object"}) if self._json_mode else {}),
+                    json_mode=self._json_mode,
                     max_tokens=500,
                     temperature=0.0,
-                    **(dict(timeout=self._timeout) if self._timeout is not None else {}),
+                    timeout=self._timeout,
                 )
 
                 raw_content: str = response.choices[0].message.content
@@ -1414,21 +1401,8 @@ class G5TranslationAccuracy:
                 },
             )
 
-        _litellm = self._get_litellm()
-        if _litellm is None:
-            return QualityResult(
-                gate_name="G5-TranslationAccuracy",
-                passed=False,
-                flagged=True,
-                details={
-                    "faithful": None,
-                    "explanation": "litellm is not available",
-                    "issues": [],
-                },
-            )
-
         try:
-            response = _litellm.completion(
+            response = call_with_fallback(
                 model=self._model,
                 messages=[
                     {"role": "system", "content": self.SYSTEM_PROMPT},
@@ -1440,10 +1414,10 @@ class G5TranslationAccuracy:
                         ),
                     },
                 ],
-                **(dict(response_format={"type": "json_object"}) if self._json_mode else {}),
+                json_mode=self._json_mode,
                 max_tokens=500,
                 temperature=0.0,
-                **(dict(timeout=self._timeout) if self._timeout is not None else {}),
+                timeout=self._timeout,
             )
 
             content: str = response.choices[0].message.content  # type: ignore[union-attr]
@@ -2600,14 +2574,6 @@ def llm_judge(
     timeout: float | None = None,
 ) -> dict[str, Any]:
     """Gate 5: LLM-based quality eval (faithfulness, terminology, style, readability 0-100)."""
-    try:
-        import litellm as _lm_mod  # noqa: PLC0415
-    except ImportError:
-        logger.error("litellm is not installed")
-        return {"faithfulness": 0, "terminology": 0, "style": 0, "readability": 0,
-                "issues": ["litellm unavailable"]}
-
-    _lm: Any = _lm_mod
     if model is None:
         model = _resolve_llm_model()
     if timeout is None:
@@ -2623,13 +2589,13 @@ def llm_judge(
     )
 
     try:
-        resp = _lm.completion(
+        resp = call_with_fallback(
             model=model,
             messages=[{"role": "user", "content": prompt}],
-            **(dict(response_format={"type": "json_object"}) if json_mode else {}),
+            json_mode=json_mode,
             max_tokens=1000,
             temperature=0.0,
-            **(dict(timeout=timeout) if timeout is not None else {}),
+            timeout=timeout,
         )
         parsed = json.loads(resp.choices[0].message.content)
     except Exception as e:

--- a/src/autoinfo/translation_qa.py
+++ b/src/autoinfo/translation_qa.py
@@ -20,6 +20,8 @@ import json
 import logging
 from typing import Any
 
+from autoinfo.llm import call_with_fallback
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_WEIGHTS = {
@@ -157,15 +159,6 @@ def back_translate(
             forward_model,
         )
 
-    _litellm = _get_litellm()
-    if _litellm is None:
-        logger.error("back_translate: litellm is not available")
-        return {
-            "back_translated_text": "",
-            "back_model": back_model,
-            "forward_model": forward_model,
-            "success": False,
-        }
     if timeout is None:
         timeout = _resolve_timeout()
 
@@ -177,7 +170,7 @@ def back_translate(
     )
 
     try:
-        response = _litellm.completion(
+        response = call_with_fallback(
             model=back_model,
             messages=[
                 {
@@ -192,7 +185,7 @@ def back_translate(
             ],
             max_tokens=4000,
             temperature=0.1,
-            **(dict(timeout=timeout) if timeout is not None else {}),
+            timeout=timeout,
         )
 
         back_text: str = response.choices[0].message.content  # type: ignore[union-attr]
@@ -254,11 +247,6 @@ def llm_judge_translation(
         ``faithfulness_score`` — 0-100 float
         ``issues`` — list of ``{"severity": str, "description": str, "position": str}``
     """
-    _litellm = _get_litellm()
-    if _litellm is None:
-        logger.error("llm_judge_translation: litellm not available")
-        return {"faithfulness_score": 0.0, "issues": [{"severity": "major", "description": "litellm unavailable", "position": "n/a"}]}
-
     if model is None:
         model = _resolve_default_model()
     if timeout is None:
@@ -287,16 +275,16 @@ def llm_judge_translation(
     )
 
     try:
-        response = _litellm.completion(
+        response = call_with_fallback(
             model=model,
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt},
             ],
-            **(dict(response_format={"type": "json_object"}) if json_mode else {}),
+            json_mode=json_mode,
             max_tokens=1000,
             temperature=0.1,
-            **(dict(timeout=timeout) if timeout is not None else {}),
+            timeout=timeout,
         )
 
         content: str = response.choices[0].message.content  # type: ignore[union-attr]
@@ -451,21 +439,6 @@ def run_back_translation_pipeline(
 # ---------------------------------------------------------------------------
 
 
-def _get_litellm() -> Any:
-    """Lazily import and return the ``litellm`` module.
-
-    Returns ``None`` when the package is not available (graceful
-    degradation for environments where LiteLLM is not installed).
-    """
-    try:
-        import litellm  # noqa: PLC0415 — deferred import
-
-        return litellm
-    except (ImportError, ModuleNotFoundError):
-        logger.error("litellm is not installed — run 'pip install litellm'")
-        return None
-
-
 def _resolve_timeout() -> float | None:
     """Resolve the per-call LLM timeout (seconds) from config.
 
@@ -593,10 +566,6 @@ def refine_translation(
     if model is None:
         model = _resolve_default_model()
 
-    _litellm = _get_litellm()
-    if _litellm is None:
-        logger.error("refine_translation: litellm is not available")
-        return {"translation": initial_translation, "model_used": model}
     if timeout is None:
         timeout = _resolve_timeout()
 
@@ -628,7 +597,7 @@ def refine_translation(
     )
 
     try:
-        response = _litellm.completion(
+        response = call_with_fallback(
             model=model,
             messages=[
                 {
@@ -643,7 +612,7 @@ def refine_translation(
             ],
             max_tokens=4000,
             temperature=0.1,
-            **(dict(timeout=timeout) if timeout is not None else {}),
+            timeout=timeout,
         )
 
         translation: str = response.choices[0].message.content  # type: ignore[union-attr]

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -19,9 +19,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from autoinfo.llm import LLMExtractor
+from autoinfo.config import Config, LLMConfig
+from autoinfo.llm import LLMExtractor, call_with_fallback
 from autoinfo.models import ExtractionResult, Item
-
 
 # ===================================================================
 # Fixtures
@@ -456,3 +456,133 @@ class TestConfigHandling:
         assert "key_points" in prompt
         # Default fields are always included even when not in the schema
         assert "entities" in prompt
+
+
+# ===================================================================
+# call_with_fallback — shared chain-walk helper (issue #147)
+# ===================================================================
+
+
+class TestCallWithFallback:
+    """``llm.call_with_fallback`` walks primary + fallback model chain.
+
+    The same helper is used by every standalone litellm call site so the
+    configured fallback chain protects all LLM paths, not just extraction.
+    """
+
+    def _config_with_fallback(self) -> Config:
+        return Config(
+            llm=LLMConfig(
+                provider="openrouter",
+                model="deepseek/deepseek-chat",
+                api_key="",
+                fallback=[LLMConfig(provider="openai", model="gpt-4o", api_key="")],
+            )
+        )
+
+    def _mock_litellm(self) -> MagicMock:
+        return MagicMock()
+
+    def test_primary_failure_falls_back(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Primary fails → fallback model is tried and its response returned."""
+        import logging
+
+        mock_lm = self._mock_litellm()
+        fallback_resp = MagicMock(choices=[MagicMock(message=MagicMock(content="ok"))])
+
+        def _side_effect(**kwargs: object) -> MagicMock:
+            if "deepseek" in str(kwargs.get("model", "")):
+                raise Exception("Primary model error")
+            return fallback_resp
+
+        mock_lm.completion.side_effect = _side_effect
+
+        caplog.set_level(logging.INFO)
+        with patch.object(LLMExtractor, "_get_litellm", return_value=mock_lm):
+            resp = call_with_fallback(
+                messages=[{"role": "user", "content": "hi"}],
+                config=self._config_with_fallback(),
+            )
+
+        assert resp is fallback_resp
+        assert mock_lm.completion.call_count == 2
+        models_called = [
+            str(c.kwargs["model"]) for c in mock_lm.completion.call_args_list
+        ]
+        assert "deepseek/deepseek-chat" in models_called
+        assert "openai/gpt-4o" in models_called
+        assert "Fallback to openai/gpt-4o succeeded" in caplog.text
+
+    def test_all_models_fail_raises(self) -> None:
+        """Every model in the chain failing raises RuntimeError."""
+        mock_lm = self._mock_litellm()
+        mock_lm.completion.side_effect = Exception("Always fails")
+
+        with patch.object(LLMExtractor, "_get_litellm", return_value=mock_lm):
+            with pytest.raises(RuntimeError, match="All LLM models"):
+                call_with_fallback(
+                    messages=[{"role": "user", "content": "hi"}],
+                    config=self._config_with_fallback(),
+                )
+        assert mock_lm.completion.call_count == 2
+
+    def test_no_fallback_single_attempt(self) -> None:
+        """Without a configured fallback the primary is attempted once."""
+        cfg = Config(
+            llm=LLMConfig(provider="openai", model="gpt-4o-mini", api_key="")
+        )
+        mock_lm = self._mock_litellm()
+        resp = MagicMock(choices=[MagicMock(message=MagicMock(content="ok"))])
+        mock_lm.completion.return_value = resp
+
+        with patch.object(LLMExtractor, "_get_litellm", return_value=mock_lm):
+            result = call_with_fallback(
+                messages=[{"role": "user", "content": "hi"}],
+                config=cfg,
+                max_tokens=512,
+                temperature=0.2,
+            )
+
+        assert result is resp
+        assert mock_lm.completion.call_count == 1
+        call_kwargs = mock_lm.completion.call_args.kwargs
+        assert call_kwargs["model"] == "openai/gpt-4o-mini"
+        assert call_kwargs["max_tokens"] == 512
+        assert call_kwargs["temperature"] == 0.2
+
+    def test_json_mode_passes_response_format(self) -> None:
+        """json_mode=True adds response_format json_object to the call."""
+        cfg = Config(
+            llm=LLMConfig(provider="openai", model="gpt-4o-mini", api_key="")
+        )
+        mock_lm = self._mock_litellm()
+        mock_lm.completion.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="{}"))]
+        )
+
+        with patch.object(LLMExtractor, "_get_litellm", return_value=mock_lm):
+            call_with_fallback(
+                messages=[{"role": "user", "content": "hi"}],
+                config=cfg,
+                json_mode=True,
+            )
+
+        call_kwargs = mock_lm.completion.call_args.kwargs
+        assert call_kwargs["response_format"] == {"type": "json_object"}
+
+    def test_primary_succeeds_no_fallback_attempt(self) -> None:
+        """Successful primary call never touches the fallback model."""
+        mock_lm = self._mock_litellm()
+        resp = MagicMock(choices=[MagicMock(message=MagicMock(content="ok"))])
+        mock_lm.completion.return_value = resp
+
+        with patch.object(LLMExtractor, "_get_litellm", return_value=mock_lm):
+            result = call_with_fallback(
+                messages=[{"role": "user", "content": "hi"}],
+                config=self._config_with_fallback(),
+            )
+
+        assert result is resp
+        assert mock_lm.completion.call_count == 1

--- a/tests/test_llm_timeout.py
+++ b/tests/test_llm_timeout.py
@@ -168,13 +168,16 @@ class TestQualityTimeout:
             choices=[MagicMock(message=MagicMock(content="88"))]
         )
         gate = G3RelevanceScoring(timeout=30.0)
-        with patch.object(G3RelevanceScoring, "_get_litellm", return_value=mock_lm):
+        with patch(
+            "autoinfo.quality.call_with_fallback",
+            return_value=mock_lm.completion.return_value,
+        ) as mock_cwf:
             gate.check(
                 sample_item,
                 ["IVF"],
                 gate_config=QualityGateConfig(name="G3", retries=1),
             )
-        assert mock_lm.completion.call_args.kwargs["timeout"] == 30.0
+        assert mock_cwf.call_args.kwargs["timeout"] == 30.0
 
     def test_g3_without_timeout_omits_kwarg(self, sample_item: Item) -> None:
         from autoinfo.config import QualityGateConfig
@@ -185,13 +188,16 @@ class TestQualityTimeout:
             choices=[MagicMock(message=MagicMock(content="88"))]
         )
         gate = G3RelevanceScoring()
-        with patch.object(G3RelevanceScoring, "_get_litellm", return_value=mock_lm):
+        with patch(
+            "autoinfo.quality.call_with_fallback",
+            return_value=mock_lm.completion.return_value,
+        ) as mock_cwf:
             gate.check(
                 sample_item,
                 ["IVF"],
                 gate_config=QualityGateConfig(name="G3", retries=1),
             )
-        assert "timeout" not in mock_lm.completion.call_args.kwargs
+        assert mock_cwf.call_args.kwargs["timeout"] is None
 
     def test_g4_passes_timeout(self, sample_item: Item, tmp_path) -> None:
         from autoinfo.quality import G4FactualConsistency
@@ -208,9 +214,12 @@ class TestQualityTimeout:
             collections_path=tmp_path,
             timeout=40.0,
         )
-        with patch.object(G4FactualConsistency, "_get_litellm", return_value=mock_lm):
+        with patch(
+            "autoinfo.quality.call_with_fallback",
+            return_value=mock_lm.completion.return_value,
+        ) as mock_cwf:
             gate.check(sample_item, extraction)
-        assert mock_lm.completion.call_args.kwargs["timeout"] == 40.0
+        assert mock_cwf.call_args.kwargs["timeout"] == 40.0
 
     def test_g5_passes_timeout(self, sample_item: Item) -> None:
         from autoinfo.quality import G5TranslationAccuracy
@@ -224,9 +233,12 @@ class TestQualityTimeout:
         extraction = _dummy_extraction(sample_item)
         extraction.custom_fields["translation"] = "Some translated text."
         gate = G5TranslationAccuracy(timeout=55.0)
-        with patch.object(G5TranslationAccuracy, "_get_litellm", return_value=mock_lm):
+        with patch(
+            "autoinfo.quality.call_with_fallback",
+            return_value=mock_lm.completion.return_value,
+        ) as mock_cwf:
             gate.check(sample_item, extraction)
-        assert mock_lm.completion.call_args.kwargs["timeout"] == 55.0
+        assert mock_cwf.call_args.kwargs["timeout"] == 55.0
 
     def test_llm_judge_passes_timeout(self) -> None:
         from autoinfo.quality import llm_judge
@@ -281,7 +293,10 @@ class TestTranslationQaTimeout:
         from autoinfo.translation_qa import back_translate
 
         mock_lm = self._patch_litellm()
-        with patch("autoinfo.translation_qa._get_litellm", return_value=mock_lm):
+        with patch(
+            "autoinfo.translation_qa.call_with_fallback",
+            return_value=mock_lm.completion.return_value,
+        ) as mock_cwf:
             back_translate(
                 source_text="hello",
                 translated_text="bonjour",
@@ -289,7 +304,7 @@ class TestTranslationQaTimeout:
                 target_lang="fr",
                 timeout=28.0,
             )
-        assert mock_lm.completion.call_args.kwargs["timeout"] == 28.0
+        assert mock_cwf.call_args.kwargs["timeout"] == 28.0
 
     def test_llm_judge_translation_passes_timeout(self) -> None:
         from autoinfo.translation_qa import llm_judge_translation
@@ -300,15 +315,21 @@ class TestTranslationQaTimeout:
                 message=MagicMock(content='{"faithfulness_score": 80, "issues": []}')
             )]
         )
-        with patch("autoinfo.translation_qa._get_litellm", return_value=mock_lm):
+        with patch(
+            "autoinfo.translation_qa.call_with_fallback",
+            return_value=mock_lm.completion.return_value,
+        ) as mock_cwf:
             llm_judge_translation("source", "back", "en", timeout=29.0)
-        assert mock_lm.completion.call_args.kwargs["timeout"] == 29.0
+        assert mock_cwf.call_args.kwargs["timeout"] == 29.0
 
     def test_refine_translation_passes_timeout(self) -> None:
         from autoinfo.translation_qa import refine_translation
 
         mock_lm = self._patch_litellm()
-        with patch("autoinfo.translation_qa._get_litellm", return_value=mock_lm):
+        with patch(
+            "autoinfo.translation_qa.call_with_fallback",
+            return_value=mock_lm.completion.return_value,
+        ) as mock_cwf:
             refine_translation(
                 source_text="hello",
                 initial_translation="bonjour",
@@ -317,7 +338,7 @@ class TestTranslationQaTimeout:
                 judge_feedback=[],
                 timeout=31.0,
             )
-        assert mock_lm.completion.call_args.kwargs["timeout"] == 31.0
+        assert mock_cwf.call_args.kwargs["timeout"] == 31.0
 
 
 # ===================================================================

--- a/tests/test_qa.py
+++ b/tests/test_qa.py
@@ -145,7 +145,7 @@ class TestQueryCollected:
     # Answer with citations
     # ------------------------------------------------------------------
 
-    @patch("autoinfo.qa._get_litellm")
+    @patch("autoinfo.qa.call_with_fallback")
     def test_answer_with_citations(
         self,
         mock_get_litellm: MagicMock,
@@ -154,7 +154,7 @@ class TestQueryCollected:
         seed_entries: dict[str, str],
     ) -> None:
         """FTS5 search yields entries; LLM returns a cited answer."""
-        mock_get_litellm.return_value = mock_litellm
+        mock_get_litellm.return_value = mock_litellm.completion.return_value
 
         result = query_collected(
             query="embryo IVF time-lapse",
@@ -174,7 +174,7 @@ class TestQueryCollected:
             assert "title" in src
 
         # Verify the LLM was called with the expected prompt shape
-        call_args = mock_litellm.completion.call_args
+        call_args = mock_get_litellm.call_args
         assert call_args is not None
         messages = call_args[1]["messages"]
         assert messages[0]["role"] == "system"
@@ -185,7 +185,7 @@ class TestQueryCollected:
     # Empty results
     # ------------------------------------------------------------------
 
-    @patch("autoinfo.qa._get_litellm")
+    @patch("autoinfo.qa.call_with_fallback")
     def test_empty_results(
         self,
         mock_get_litellm: MagicMock,
@@ -194,7 +194,7 @@ class TestQueryCollected:
         seed_entries: dict[str, str],
     ) -> None:
         """No matching entries → graceful empty response, no LLM call."""
-        mock_get_litellm.return_value = mock_litellm
+        mock_get_litellm.return_value = mock_litellm.completion.return_value
 
         result = query_collected(
             query="xyznonexistent12345",
@@ -207,13 +207,13 @@ class TestQueryCollected:
         assert result["sources"] == []
 
         # LLM should NOT be called when there are no sources
-        mock_litellm.completion.assert_not_called()
+        mock_get_litellm.assert_not_called()
 
     # ------------------------------------------------------------------
     # Explicit content_ids
     # ------------------------------------------------------------------
 
-    @patch("autoinfo.qa._get_litellm")
+    @patch("autoinfo.qa.call_with_fallback")
     def test_explicit_content_ids(
         self,
         mock_get_litellm: MagicMock,
@@ -222,7 +222,7 @@ class TestQueryCollected:
         seed_entries: dict[str, str],
     ) -> None:
         """When content_ids is provided, only those entries are used."""
-        mock_get_litellm.return_value = mock_litellm
+        mock_get_litellm.return_value = mock_litellm.completion.return_value
 
         # Pick two specific entry IDs
         entry_ids = list(seed_entries.keys())
@@ -247,7 +247,7 @@ class TestQueryCollected:
     # Independent queries
     # ------------------------------------------------------------------
 
-    @patch("autoinfo.qa._get_litellm")
+    @patch("autoinfo.qa.call_with_fallback")
     def test_independent_queries(
         self,
         mock_get_litellm: MagicMock,
@@ -256,7 +256,7 @@ class TestQueryCollected:
         seed_entries: dict[str, str],
     ) -> None:
         """Each call is stateless — second query ignores first."""
-        mock_get_litellm.return_value = mock_litellm
+        mock_get_litellm.return_value = mock_litellm.completion.return_value
 
         # First query
         result1 = query_collected(
@@ -275,12 +275,12 @@ class TestQueryCollected:
         assert result2["answer"]
 
         # Verify LLM was called twice with full conversation each time
-        assert mock_litellm.completion.call_count == 2
+        assert mock_get_litellm.call_count == 2
 
         # Each call should contain the full article context (not just
         # a continuation).  Check that both messages include the
         # article content.
-        for call_args in mock_litellm.completion.call_args_list:
+        for call_args in mock_get_litellm.call_args_list:
             messages = call_args[1]["messages"]
             user_msg = messages[1]["content"]
             assert "Question: embryo IVF" in user_msg
@@ -290,7 +290,7 @@ class TestQueryCollected:
     # content_ids with non-existent IDs
     # ------------------------------------------------------------------
 
-    @patch("autoinfo.qa._get_litellm")
+    @patch("autoinfo.qa.call_with_fallback")
     def test_content_ids_unknown(
         self,
         mock_get_litellm: MagicMock,
@@ -298,7 +298,7 @@ class TestQueryCollected:
         kb_store: KBStore,
     ) -> None:
         """content_ids that don't exist → empty sources."""
-        mock_get_litellm.return_value = mock_litellm
+        mock_get_litellm.return_value = mock_litellm.completion.return_value
 
         result = query_collected(
             query="anything",
@@ -309,4 +309,4 @@ class TestQueryCollected:
 
         assert "No relevant articles found" in result["answer"]
         assert result["sources"] == []
-        mock_litellm.completion.assert_not_called()
+        mock_get_litellm.assert_not_called()

--- a/tests/test_quality_g4.py
+++ b/tests/test_quality_g4.py
@@ -184,7 +184,7 @@ class TestG4FactualConsistencyCheck:
         mock_llm = _mock_litellm(
             {"contradiction": False, "explanation": "Summary matches source."}
         )
-        with patch.object(G4FactualConsistency, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", return_value=mock_llm.completion.return_value):
             g4 = G4FactualConsistency(model="test/test")
             result = g4.check(sample_item, sample_extraction)
 
@@ -203,7 +203,7 @@ class TestG4FactualConsistencyCheck:
                 "explanation": "Summary says decrease but source says increase.",
             }
         )
-        with patch.object(G4FactualConsistency, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", return_value=mock_llm.completion.return_value):
             g4 = G4FactualConsistency(model="test/test")
             result = g4.check(sample_item, contradictory_extraction)
 
@@ -217,7 +217,7 @@ class TestG4FactualConsistencyCheck:
     ) -> None:
         """LLM returns invalid JSON → flagged as uncertain (contradiction=None)."""
         mock_llm = _mock_litellm_raw("this is not json")
-        with patch.object(G4FactualConsistency, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", return_value=mock_llm.completion.return_value):
             g4 = G4FactualConsistency(model="test/test")
             result = g4.check(sample_item, sample_extraction)
 
@@ -231,7 +231,7 @@ class TestG4FactualConsistencyCheck:
     ) -> None:
         """LLM returns JSON missing 'contradiction' key → treated as no contradiction."""
         mock_llm = _mock_litellm({"explanation": "No contradiction field"})
-        with patch.object(G4FactualConsistency, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", return_value=mock_llm.completion.return_value):
             g4 = G4FactualConsistency(model="test/test")
             result = g4.check(sample_item, sample_extraction)
 
@@ -259,7 +259,7 @@ class TestG4FactualConsistencyCheck:
         self, sample_item: Item, sample_extraction: ExtractionResult
     ) -> None:
         """When litellm is not installed, return flagged result with explanation."""
-        with patch.object(G4FactualConsistency, "_get_litellm", return_value=None):
+        with patch("autoinfo.quality.call_with_fallback", side_effect=RuntimeError("litellm is not available")):
             g4 = G4FactualConsistency(model="test/test")
             result = g4.check(sample_item, sample_extraction)
 
@@ -274,7 +274,7 @@ class TestG4FactualConsistencyCheck:
         """LLM raises an exception → returned as flagged uncertain."""
         mock_llm = MagicMock()
         mock_llm.completion.side_effect = RuntimeError("API timeout")
-        with patch.object(G4FactualConsistency, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", return_value=mock_llm.completion.return_value):
             g4 = G4FactualConsistency(model="test/test")
             result = g4.check(sample_item, sample_extraction)
 

--- a/tests/test_quality_g5.py
+++ b/tests/test_quality_g5.py
@@ -221,7 +221,7 @@ class TestG5TranslationAccuracyCheck:
                 "issues": [],
             }
         )
-        with patch.object(G5TranslationAccuracy, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", return_value=mock_llm.completion.return_value):
             g5 = G5TranslationAccuracy(model="test/test")
             result = g5.check(sample_item, faithful_extraction)
 
@@ -241,7 +241,7 @@ class TestG5TranslationAccuracyCheck:
                 "issues": ["Changed 'improves' to 'reduces'", "Added negative claim about safety"],
             }
         )
-        with patch.object(G5TranslationAccuracy, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", return_value=mock_llm.completion.return_value):
             g5 = G5TranslationAccuracy(model="test/test")
             result = g5.check(sample_item, unfaithful_extraction)
 
@@ -256,7 +256,7 @@ class TestG5TranslationAccuracyCheck:
     ) -> None:
         """LLM returns invalid JSON → flagged as uncertain (faithful=None)."""
         mock_llm = _mock_litellm_raw("this is not json")
-        with patch.object(G5TranslationAccuracy, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", return_value=mock_llm.completion.return_value):
             g5 = G5TranslationAccuracy(model="test/test")
             result = g5.check(sample_item, faithful_extraction)
 
@@ -270,7 +270,7 @@ class TestG5TranslationAccuracyCheck:
     ) -> None:
         """LLM returns JSON missing 'faithful' key → treated as unfaithful."""
         mock_llm = _mock_litellm({"explanation": "No faithful field", "issues": []})
-        with patch.object(G5TranslationAccuracy, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", return_value=mock_llm.completion.return_value):
             g5 = G5TranslationAccuracy(model="test/test")
             result = g5.check(sample_item, faithful_extraction)
 
@@ -295,7 +295,7 @@ class TestG5TranslationAccuracyCheck:
         self, sample_item: Item, faithful_extraction: ExtractionResult
     ) -> None:
         """When litellm is not installed, return flagged result with explanation."""
-        with patch.object(G5TranslationAccuracy, "_get_litellm", return_value=None):
+        with patch("autoinfo.quality.call_with_fallback", side_effect=RuntimeError("litellm is not available")):
             g5 = G5TranslationAccuracy(model="test/test")
             result = g5.check(sample_item, faithful_extraction)
 
@@ -310,7 +310,7 @@ class TestG5TranslationAccuracyCheck:
         """LLM raises an exception → returned as flagged uncertain."""
         mock_llm = MagicMock()
         mock_llm.completion.side_effect = RuntimeError("API timeout")
-        with patch.object(G5TranslationAccuracy, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", return_value=mock_llm.completion.return_value):
             g5 = G5TranslationAccuracy(model="test/test")
             result = g5.check(sample_item, faithful_extraction)
 
@@ -330,14 +330,14 @@ class TestG5TranslationAccuracyCheck:
                 "issues": [],
             }
         )
-        with patch.object(G5TranslationAccuracy, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", return_value=mock_llm.completion.return_value) as mock_cwf:
             g5 = G5TranslationAccuracy(model="test/test")
             result = g5.check(sample_item, faithful_extraction)
 
         assert result.passed is True
         # Verify the LLM was called with the translation text
-        call_args = mock_llm.completion.call_args
-        user_msg = call_args[1]["messages"][1]["content"]
+        call_args = mock_cwf.call_args
+        user_msg = call_args.kwargs["messages"][1]["content"]
         assert "Una recente studio" in user_msg
 
 

--- a/tests/test_v1_5_integration.py
+++ b/tests/test_v1_5_integration.py
@@ -355,14 +355,17 @@ class TestQualityGatePipelineIntegration:
             {"contradiction": False, "explanation": "Second check passed."},
         ])
 
-        with patch.object(G4FactualConsistency, "_get_litellm", return_value=mock_llm):
+        with patch(
+            "autoinfo.quality.call_with_fallback",
+            side_effect=mock_llm.completion.side_effect,
+        ) as mock_cwf:
             g4 = G4FactualConsistency(model="test/test-model")
             result = g4.check(item, extraction, gate_config=gate_config)
 
         assert result.passed is True
         assert result.details["contradiction"] is False
-        assert mock_llm.completion.call_count == 2
-        model_args = [call.kwargs.get("model") for call in mock_llm.completion.call_args_list]
+        assert mock_cwf.call_count == 2
+        model_args = [call.kwargs.get("model") for call in mock_cwf.call_args_list]
         assert model_args[0] == "test/test-model"
         assert model_args[1] == "test/model-two"
 

--- a/tests/test_v1_5_quality_gates.py
+++ b/tests/test_v1_5_quality_gates.py
@@ -1314,7 +1314,7 @@ class TestG4RetryChain:
         mock_llm = _g4_mock_litellm_sequential([
             {"contradiction": False, "explanation": "Summary matches source."},
         ])
-        with patch.object(G4FactualConsistency, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", side_effect=mock_llm.completion.side_effect) as mock_cwf:
             g4 = G4FactualConsistency(model="test/test-model")
             result = g4.check(item, extraction, gate_config=gate_config)
 
@@ -1322,7 +1322,7 @@ class TestG4RetryChain:
         assert result.flagged is False
         assert result.details["contradiction"] is False
         assert result.score == 1.0
-        assert mock_llm.completion.call_count == 1
+        assert mock_cwf.call_count == 1
 
     def test_retries_twice_succeeds_on_third(self) -> None:
         """G4 retries after contradiction; succeeds on 3rd attempt with different model."""
@@ -1341,7 +1341,7 @@ class TestG4RetryChain:
             },
             {"contradiction": False, "explanation": "Summary matches source on re-evaluation."},
         ])
-        with patch.object(G4FactualConsistency, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", side_effect=mock_llm.completion.side_effect) as mock_cwf:
             g4 = G4FactualConsistency(model="test/test-model")
             result = g4.check(item, extraction, gate_config=gate_config)
 
@@ -1349,8 +1349,8 @@ class TestG4RetryChain:
         assert result.flagged is False
         assert result.details["contradiction"] is False
         assert result.score == 1.0
-        assert mock_llm.completion.call_count == 3
-        model_args = [call.kwargs.get("model") for call in mock_llm.completion.call_args_list]
+        assert mock_cwf.call_count == 3
+        model_args = [call.kwargs.get("model") for call in mock_cwf.call_args_list]
         assert model_args[0] == "test/test-model"
         assert model_args[1] == "test/model-two"
         assert model_args[2] == "test/model-three"
@@ -1366,7 +1366,7 @@ class TestG4RetryChain:
             {"contradiction": True, "explanation": "Second check: still contradictory."},
             {"contradiction": True, "explanation": "Third check: still contradicts."},
         ])
-        with patch.object(G4FactualConsistency, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", side_effect=mock_llm.completion.side_effect) as mock_cwf:
             g4 = G4FactualConsistency(model="test/test-model")
             result = g4.check(item, extraction, gate_config=gate_config)
 
@@ -1376,7 +1376,7 @@ class TestG4RetryChain:
         assert result.details["contradiction"] is True
         assert result.details["action"] == "block"
         assert result.details["retry_count"] == 3
-        assert mock_llm.completion.call_count == 3
+        assert mock_cwf.call_count == 3
 
     def test_failed_json_written_on_block(self, tmp_path: Path) -> None:
         """When G4 blocks, _failed/ diagnostics JSON is written."""
@@ -1391,7 +1391,7 @@ class TestG4RetryChain:
         ])
 
         collections_dir = tmp_path / "collections"
-        with patch.object(G4FactualConsistency, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", side_effect=mock_llm.completion.side_effect) as mock_cwf:
             g4 = G4FactualConsistency(
                 model="test/test-model",
                 collections_path=str(collections_dir),
@@ -1427,7 +1427,7 @@ class TestG4RetryChain:
         gate_config = _g4_gate_config(retries=3)
 
         mock_llm = MagicMock()
-        with patch.object(G4FactualConsistency, "_get_litellm", return_value=mock_llm):
+        with patch("autoinfo.quality.call_with_fallback", side_effect=mock_llm.completion.side_effect) as mock_cwf:
             g4 = G4FactualConsistency(model="test/test-model")
             result = g4.check(item, extraction, gate_config=gate_config)
 


### PR DESCRIPTION
## Summary

Fixes #147. AutoInfo's LLM fallback chain only covered the LLMExtractor extraction path — **17 standalone `litellm.completion` call sites** (the issue claimed 9; audit found 17) bypassed the configured `llm.fallback` chain.

Adds one shared helper `llm.call_with_fallback(messages, ...)` that walks `[primary] + config.llm.fallback`, retrying each model in order and returning the first success (logs "Fallback to X succeeded after primary Y failed"; raises `RuntimeError` only when all fail). All 17 sites now route through it:

| File | Sites |
|------|-------|
| output/__init__.py | 5 (digest/translation/tutorial/presentation/simplify) |
| quality.py | 4 (G3 _llm_score, G4, G5, D-gate llm_judge) |
| translation_qa.py | 3 (back_translate/judge/refine) |
| mcp/validation.py | 1 (_llm_judge) |
| mcp/server.py | 1 (suggest_keywords) |
| cli/keywords.py | 1 (suggest) |
| qa.py, cefr.py | 1 each |

`LLMExtractor._call_llm` was refactored to reuse the same helper (eliminates the duplicated chain-walk — no repeated implementation). `${ENV}` placeholders in fallback keys are expanded; call sites that don't pass key/base_url keep env-based resolution (behavior-preserving).

## Verification

- New `TestCallWithFallback` (5 tests): primary→fallback, all-fail, no-fallback, json_mode, primary-success
- 415 tests across all touched modules pass; full suite shows **no new failures** (the one g5 pipeline ordering flake is pre-existing on HEAD)
- ruff: touched files net **-24 errors** (0 new); lsp clean
- All 15 original sites + 2 additional (quality G3/D-gate) verified replaced — zero standalone `.completion(` calls remain outside llm.py

## Commits

- `feat(llm): shared call_with_fallback helper protects all 17 LLM call sites (#147)`

## Related

Closes #147