### PR TITLE
fix(validation): strip absolute prefix in _tier_subpath + collect 03-Wiki in KB scenarios (#143 #144)

### DIFF
--- a/scripts/validation_delivery.py
+++ b/scripts/validation_delivery.py
@@ -93,9 +93,18 @@ def _tier_subpath(src: Path) -> Path:
     """Path below '<root>/<domain>/' so nested structure survives the copy.
 
     E.g. ``knowledge/medical-research/01-Raw/crispr/2026-08-05-x.md`` maps to
-    ``01-Raw/crispr/2026-08-05-x.md``; shallow paths fall back to the bare name.
+    ``01-Raw/crispr/2026-08-05-x.md``; shallow paths fall back to the bare
+    name.  Absolute inputs under the repo root are relativized first so the
+    mount/user prefix is never embedded in the package (issue #143).
     """
-    parts = src.parts
+    cwd = Path.cwd().resolve()
+    try:
+        rel = src.resolve().relative_to(cwd)
+    except (ValueError, OSError):
+        # Not under the repo root — keep the historical slice behaviour.
+        parts = src.parts
+        return Path(*parts[2:]) if len(parts) >= 3 else Path(src.name)
+    parts = rel.parts
     return Path(*parts[2:]) if len(parts) >= 3 else Path(src.name)
 
 

--- a/src/autoinfo/mcp/scenarios/kb-draft.yaml
+++ b/src/autoinfo/mcp/scenarios/kb-draft.yaml
@@ -12,6 +12,7 @@ requires_env: []
 collect_artifacts:
   - "knowledge/medical-research/01-Raw/**/*.md"
   - "knowledge/medical-research/02-Draft/**/*.md"
+  - "knowledge/medical-research/03-Wiki/**/*.md"
 steps:
   - name: "create_kb_entry writes to 01-Raw"
     tool: create_kb_entry

--- a/src/autoinfo/mcp/scenarios/kb-promote.yaml
+++ b/src/autoinfo/mcp/scenarios/kb-promote.yaml
@@ -15,6 +15,7 @@ requires_domain: ["medical-research"]
 collect_artifacts:
   - "knowledge/medical-research/01-Raw/**/*.md"
   - "knowledge/medical-research/02-Draft/**/*.md"
+  - "knowledge/medical-research/03-Wiki/**/*.md"
 steps:
   - name: "create_kb_entry writes to 01-Raw"
     tool: create_kb_entry

--- a/tests/test_validation_coverage.py
+++ b/tests/test_validation_coverage.py
@@ -65,6 +65,7 @@ def test_kb_promote_yaml_exists_and_parses():
     assert data["collect_artifacts"] == [
         "knowledge/medical-research/01-Raw/**/*.md",
         "knowledge/medical-research/02-Draft/**/*.md",
+        "knowledge/medical-research/03-Wiki/**/*.md",
     ]
 
 

--- a/tests/test_validation_delivery.py
+++ b/tests/test_validation_delivery.py
@@ -763,3 +763,59 @@ def test_package_matrix_llm_absent_marks_gated_unconfigured(tmp_path: Path, monk
     assert "未配置unconfigured" in report
     assert "| tutorial | 空gap |" not in report
     assert "| tutorial | 未配置unconfigured |" in report
+
+
+# ---------------------------------------------------------------------------
+# _tier_subpath — absolute-prefix stripping (issue #143)
+# ---------------------------------------------------------------------------
+
+
+def test_tier_subpath_absolute_repo_path_relativized():
+    """Absolute paths under the repo root map to the tier subpath only."""
+    cwd = Path.cwd()
+    src = cwd / "knowledge" / "medical-research" / "01-Raw" / "general" / "x.md"
+    assert vd._tier_subpath(src) == Path("01-Raw/general/x.md")
+
+
+def test_tier_subpath_absolute_draft_path_relativized():
+    """Absolute 02-Draft path under the repo root → tier subpath, no prefix."""
+    cwd = Path.cwd()
+    src = cwd / "knowledge" / "medical-research" / "02-Draft" / "d.md"
+    assert vd._tier_subpath(src) == Path("02-Draft/d.md")
+
+
+def test_tier_subpath_relative_paths_unchanged():
+    """Repo-relative inputs keep the historical slice behaviour."""
+    assert vd._tier_subpath(Path("knowledge/medical-research/01-Raw/w.md")) == Path("01-Raw/w.md")
+    assert vd._tier_subpath(Path("collections/medical-research/z.json")) == Path("z.json")
+    assert vd._tier_subpath(Path("outputs/medical-research/digest.md")) == Path("digest.md")
+
+
+def test_tier_subpath_shallow_bare_name():
+    """Shallow paths fall back to the bare file name."""
+    assert vd._tier_subpath(Path("digest.md")) == Path("digest.md")
+
+
+def test_tier_subpath_outside_repo_keeps_slice():
+    """Paths outside the repo root keep the historical slice behaviour."""
+    src = Path("/tmp/outside/knowledge/medical-research/02-Draft/d.md")
+    assert vd._tier_subpath(src) == Path("outside/knowledge/medical-research/02-Draft/d.md")
+
+
+# ---------------------------------------------------------------------------
+# KB scenario artifact globs — 03-Wiki coverage (issue #144)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fname",
+    ["kb-promote.yaml", "kb-draft.yaml"],
+)
+def test_kb_scenarios_collect_03_wiki(fname: str):
+    """KB scenarios glob all three tiers so 03-KB is never empty (#144)."""
+    scenario = ROOT / "src" / "autoinfo" / "mcp" / "scenarios" / fname
+    data = yaml.safe_load(scenario.read_text(encoding="utf-8"))
+    globs = data["collect_artifacts"]
+    assert any("03-Wiki" in g for g in globs)
+    assert any("01-Raw" in g for g in globs)
+    assert any("02-Draft" in g for g in globs)


### PR DESCRIPTION
## Summary

Fixes #143 and #144 (both verified NOT-FIXED by the 08-07 delivery-package investigation).

**#143 — RAW 路径带绝对路径前缀**: `_tier_subpath` (scripts/validation_delivery.py) blindly sliced `parts[2:]`; for absolute artifact paths (`validation.py:1326` `Path.cwd().glob` yields absolute) it embedded the mount/user prefix — runtime evidence: every file delivered under `01-RAW/d/贯维/AutoInfo/knowledge/...`. Fix: relativize against the repo root first (`src.resolve().relative_to(cwd)`), then slice. Relative-path behavior unchanged; out-of-repo paths keep the historical slice.

**#144 — 03-KB 目录空**: root cause was scenario-side — `kb-promote.yaml`/`kb-draft.yaml` `collect_artifacts` globbed only `01-Raw` + `02-Draft`; since `promote_kb_draft` moves the Draft file to 03-Wiki *before* artifact collection, 02-Draft was empty and no 03-Wiki glob existed → 03-KB received nothing. Fix: add `knowledge/medical-research/03-Wiki/**/*.md` to both scenarios (`data-lifecycle-e2e.yaml` already had all three tiers).

## Verification

- New `test_tier_subpath_absolute_repo_path_relativized` etc. (5 tests) — absolute repo paths map to clean tier subpaths; relative/shallow/out-of-repo behavior preserved
- Parametrized glob-guard test asserts kb-promote/kb-draft declare all three tier globs
- `tests/test_validation_delivery.py`: 37 passed (30 existing + 7 new); ruff clean
- Static repro: `/mnt/d/贯维/AutoInfo/knowledge/medical-research/02-Draft/x.md` → `02-Draft/x.md` (was `d/贯维/AutoInfo/knowledge/medical-research/02-Draft/x.md`)

## Commits

- `fix(validation): strip absolute prefix in _tier_subpath + collect 03-Wiki in KB scenarios (#143 #144)`

## Related

Closes #143, Closes #144