### PR TITLE
feat(validation): enforce error_actionable assertion in _step_assert (#141)

### DIFF
--- a/src/autoinfo/mcp/scenarios/error-boundary.yaml
+++ b/src/autoinfo/mcp/scenarios/error-boundary.yaml
@@ -12,12 +12,12 @@ category: errors
 requires_env: []
 steps:
   - name: "unknown tool returns UnknownTool"
-    tool: definitely_not_a_real_tool
+    tool: nonexistent_tool_xyz
     arguments: {}
     expect:
       success: false
       error_code: "UnknownTool"
-      error_actionable: true
+      error_actionable: false
 
   - name: "nonexistent domain schema returns DomainNotFound"
     tool: get_domain_schema

--- a/src/autoinfo/mcp/scenarios/error-boundary.yaml
+++ b/src/autoinfo/mcp/scenarios/error-boundary.yaml
@@ -12,7 +12,7 @@ category: errors
 requires_env: []
 steps:
   - name: "unknown tool returns UnknownTool"
-    tool: nonexistent_tool_xyz
+    tool: definitely_not_a_real_tool
     arguments: {}
     expect:
       success: false

--- a/src/autoinfo/mcp/validation.py
+++ b/src/autoinfo/mcp/validation.py
@@ -430,7 +430,7 @@ def _step_assert(
     """Run assertions on a single tool-call envelope and return a step result.
 
     Supports the canonical envelope fields (``success`` / ``data_has`` /
-    ``error_code``) plus surface-specific fields:
+    ``error_code`` / ``error_actionable``) plus surface-specific fields:
 
     - CLI (``kind: cli``): ``exit_code``, ``stdout_has``, ``stderr_has``
     - HTTP (``kind: http``): ``status_code``, ``json_has``
@@ -571,6 +571,25 @@ def _step_assert(
                     "detail": (
                         f"expected error_code={error_code}, "
                         f"got {actual}: {env}"
+                    ),
+                }
+
+        # error_actionable (issue #141) — verify the actionable boolean
+        # hint agents use to remediate is present on the error envelope.
+        expected_actionable = expect.get("error_actionable")
+        if expected_actionable is not None:
+            error = env.get("error", {})
+            actual_actionable = (
+                error.get("actionable") if isinstance(error, dict) else None
+            )
+            if actual_actionable != expected_actionable:
+                return {
+                    "name": step_name,
+                    "tool": tool,
+                    "status": "failed",
+                    "detail": (
+                        f"expected error_actionable={expected_actionable}, "
+                        f"got {actual_actionable}: {env}"
                     ),
                 }
 

--- a/tests/test_validation_delivery.py
+++ b/tests/test_validation_delivery.py
@@ -640,7 +640,9 @@ def test_error_boundary_asserts_actionable_on_error_envelope():
     error_steps = [s for s in data["steps"] if s["expect"].get("success") is False]
     assert error_steps, "expected error-envelope steps"
     for step in error_steps:
-        assert step["expect"].get("error_actionable") is True, (
+        # Every error step must pin the actionable boolean (true OR false —
+        # UnknownTool is genuinely not actionable, #141).
+        assert step["expect"].get("error_actionable") is not None, (
             f"step '{step['name']}' must assert error.actionable"
         )
         assert step["expect"]["error_code"], f"step '{step['name']}' keeps error_code"

--- a/tests/test_validation_tools.py
+++ b/tests/test_validation_tools.py
@@ -269,6 +269,11 @@ steps:
             return {"success": True, "data": {"result": "ok"}}
         if name == "fake_error":
             return {"success": False, "error": {"code": "Timeout", "message": "timeout"}}
+        if name == "fake_error_actionable":
+            return {
+                "success": False,
+                "error": {"code": "Timeout", "message": "timeout", "actionable": True},
+            }
         if name == "bad_tool":
             return 42  # non-dict response — should trigger exception
         return {"success": True, "data": {}}
@@ -329,6 +334,49 @@ steps:
         assert result["status"] == "failed"
         assert result["steps"][0]["status"] == "failed"
         assert "WrongCode" in result["steps"][0].get("detail", "")
+
+    async def test_error_actionable_check_passes_when_actionable(
+        self, tmp_path: Path
+    ) -> None:
+        """error_actionable: true passes when the envelope carries actionable."""
+        sd = tmp_path / "scenarios"
+        sd.mkdir()
+        (sd / "act-ok.yaml").write_text(
+            "name: act-ok\ndescription: Test\nsteps:\n"
+            "  - name: step\n    tool: fake_error_actionable\n    arguments: {}\n"
+            "    expect:\n      success: false\n      error_code: Timeout\n"
+            "      error_actionable: true\n",
+            encoding="utf-8",
+        )
+        result = await run_scenario(
+            "act-ok",
+            dispatch=self._fake_dispatch,
+            scenarios_dir=sd,
+        )
+        assert result["status"] == "passed"
+        assert result["steps"][0]["status"] == "passed"
+
+    async def test_error_actionable_check_fails_when_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """error_actionable: true fails when the envelope omits actionable."""
+        sd = tmp_path / "scenarios"
+        sd.mkdir()
+        (sd / "act-bad.yaml").write_text(
+            "name: act-bad\ndescription: Test\nsteps:\n"
+            "  - name: step\n    tool: fake_error\n    arguments: {}\n"
+            "    expect:\n      success: false\n      error_code: Timeout\n"
+            "      error_actionable: true\n",
+            encoding="utf-8",
+        )
+        result = await run_scenario(
+            "act-bad",
+            dispatch=self._fake_dispatch,
+            scenarios_dir=sd,
+        )
+        assert result["status"] == "failed"
+        assert result["steps"][0]["status"] == "failed"
+        assert "actionable" in result["steps"][0].get("detail", "")
 
     async def test_requires_env_reports_unconfigured(self, scenario_dir: Path) -> None:
         """Scenario with missing env var should report 'unconfigured' — not


### PR DESCRIPTION
## Summary

Fixes #141 (the PARTIAL gap). The UX-metrics half (UX_OK/completion_rate, enduser-journey scenario) already landed in the E-wave; the missing piece was that `error-boundary.yaml` declared `error_actionable: true` on its steps but `_step_assert` (validation.py) never parsed the key — the assertion was declarative-only, so the human-machine-handoff quality (errors carrying an `actionable` remediation hint) went unverified.

**Enforcement added**: `_step_assert` now checks `expect.error_actionable` (mirroring the existing `error_code` branch) — the envelope's `error.actionable` must equal the expected boolean, or the step fails.

**Scenario corrected**: the `UnknownTool` step expected `error_actionable: true`, but the server genuinely returns `actionable: false` (an "unknown tool" message carries no remediation hint — `test_mcp_server.py` pins this). Corrected to `false`; `DomainNotFound` and `NotFound` are `true` and verified.

## Verification

- New tests (RED→GREEN): `test_error_actionable_check_fails_when_missing` (fails before the fix: step passed with enforcement absent), `test_error_actionable_check_passes_when_actionable`
- `tests/test_validation_tools.py` + delivery/coverage/report: 136 passed; ruff clean
- Live `run_scenario('error-boundary')` through the real MCP dispatch: **3/3 passed** (UnknownTool actionable=False, DomainNotFound/NotFound actionable=True)

## Commits

- `feat(validation): enforce error_actionable assertion in _step_assert (#141)`

## Related

Closes #141