### PR TITLE
feat(matrix): full-capability end-user matrix + scenario-library coverage check

### DIFF
--- a/docs/dev/specs/end-user-matrix.yaml
+++ b/docs/dev/specs/end-user-matrix.yaml
@@ -1,21 +1,22 @@
-# End-User Coverage Matrix (E8, issue #131)
+# End-User Coverage Matrix (E8, issue #131 — full-capability revision)
 #
-# Sparse matrix spec: 13 demo domains x 8 products x 7 formats.
-# The generator scripts/coverage_matrix.py renders matrix-report.md from
-# this spec plus real evidence (outputs/** persisted artifacts and the
-# validation_delivery manifest), marking every cell as:
+# Sparse matrix spec: 13 demo domains x 8 products x 7 formats, PLUS
+# source-platform coverage (27 collector types) and KB-tier coverage
+# (01-Raw / 02-Draft / 03-Wiki).
 #
-#   有produced             evidence found for this domain x product x format
-#   空gap                  required cell with no evidence and the LLM is
-#                          configured (or the product is not LLM-gated)
+# This revision fixes the spec drift found in the 2026-08-07 audit: the
+# old spec declared only 13 required cells across 2 domains while the
+# codebase implements 13 domains x 8 products x 7 formats x 27 sources.
+# The required set now reflects the FULL implemented capability surface.
+#
+# Statuses (rendered by scripts/coverage_matrix.py):
+#   有produced             evidence found
+#   空gap                  required cell with no evidence (LLM available)
 #   不适用not-applicable   non-required cell with no evidence
-#   未配置unconfigured     required cell whose product is LLM-gated and the
-#                          LLM key is unavailable (Oracle R8: NOT a gap)
+#   未配置unconfigured     required cell whose product is LLM-gated while
+#                          the LLM key is unavailable (NOT a gap)
 #
-# required_cells (13, Oracle R8): digest/report in json+html, tutorial and
-# presentation in markdown, across medical-research and tech-ai-developer,
-# plus one audio cell (medical-research digest audio).
-version: 1
+version: 2
 
 products:
   - digest
@@ -36,6 +37,7 @@ formats:
   - epub
   - audiobook
 
+# All 13 demo domains implemented in src/autoinfo/data/domains/.
 domains:
   - medical-research
   - ai-commercial
@@ -51,27 +53,164 @@ domains:
   - b2b
   - retail
 
-# Oracle R8: the 13 cells that MUST be produced by validation scenarios.
+# All 27 collector types registered in the MCP source-type registry
+# (src/autoinfo/mcp/server.py SOURCE_TYPES).
+source_platforms:
+  - rss
+  - api
+  - web
+  - webhook
+  - email
+  - pdf
+  - apple_podcasts
+  - akshare
+  - ap_api
+  - bilibili
+  - core
+  - dblp
+  - gdelt
+  - huggingface
+  - kaggle
+  - nyt
+  - openalex
+  - quandl
+  - reddit
+  - reuters
+  - sec_edgar
+  - ssrn
+  - spotify
+  - unpaywall
+  - yahoo_finance
+  - youtube
+  - edx_sitemap
+
+# KB tiers — the data pipeline depth an end-user can inspect.
+kb_tiers:
+  - 01-Raw
+  - 02-Draft
+  - 03-Wiki
+
+# Required cells — full implemented surface across the 2 configured demo
+# domains (tech-ai-developer + medical-research). Every product x format
+# combination that the codebase can produce must have evidence.
 required_cells:
-  # medical-research — digest + report (json/html), tutorial/presentation (md), audio
-  - {domain: medical-research, product: digest, format: json}
+  # ---- medical-research: all 8 products x 7 formats (56 cells) ----
+  - {domain: medical-research, product: digest, format: markdown}
   - {domain: medical-research, product: digest, format: html}
-  - {domain: medical-research, product: report, format: json}
-  - {domain: medical-research, product: report, format: html}
-  - {domain: medical-research, product: tutorial, format: markdown}
-  - {domain: medical-research, product: presentation, format: markdown}
+  - {domain: medical-research, product: digest, format: json}
+  - {domain: medical-research, product: digest, format: agent}
   - {domain: medical-research, product: digest, format: audio}
-  # tech-ai-developer — digest + report (json/html), tutorial/presentation (md)
-  - {domain: tech-ai-developer, product: digest, format: json}
+  - {domain: medical-research, product: digest, format: epub}
+  - {domain: medical-research, product: digest, format: audiobook}
+  - {domain: medical-research, product: report, format: markdown}
+  - {domain: medical-research, product: report, format: html}
+  - {domain: medical-research, product: report, format: json}
+  - {domain: medical-research, product: report, format: agent}
+  - {domain: medical-research, product: report, format: audio}
+  - {domain: medical-research, product: report, format: epub}
+  - {domain: medical-research, product: report, format: audiobook}
+  - {domain: medical-research, product: tutorial, format: markdown}
+  - {domain: medical-research, product: tutorial, format: html}
+  - {domain: medical-research, product: tutorial, format: json}
+  - {domain: medical-research, product: tutorial, format: agent}
+  - {domain: medical-research, product: tutorial, format: audio}
+  - {domain: medical-research, product: tutorial, format: epub}
+  - {domain: medical-research, product: tutorial, format: audiobook}
+  - {domain: medical-research, product: presentation, format: markdown}
+  - {domain: medical-research, product: presentation, format: html}
+  - {domain: medical-research, product: presentation, format: json}
+  - {domain: medical-research, product: presentation, format: agent}
+  - {domain: medical-research, product: presentation, format: audio}
+  - {domain: medical-research, product: presentation, format: epub}
+  - {domain: medical-research, product: presentation, format: audiobook}
+  - {domain: medical-research, product: premium-briefing, format: markdown}
+  - {domain: medical-research, product: premium-briefing, format: html}
+  - {domain: medical-research, product: premium-briefing, format: json}
+  - {domain: medical-research, product: premium-briefing, format: agent}
+  - {domain: medical-research, product: premium-briefing, format: audio}
+  - {domain: medical-research, product: premium-briefing, format: epub}
+  - {domain: medical-research, product: premium-briefing, format: audiobook}
+  - {domain: medical-research, product: column, format: markdown}
+  - {domain: medical-research, product: column, format: html}
+  - {domain: medical-research, product: column, format: json}
+  - {domain: medical-research, product: column, format: agent}
+  - {domain: medical-research, product: column, format: audio}
+  - {domain: medical-research, product: column, format: epub}
+  - {domain: medical-research, product: column, format: audiobook}
+  - {domain: medical-research, product: magazine-digest, format: markdown}
+  - {domain: medical-research, product: magazine-digest, format: html}
+  - {domain: medical-research, product: magazine-digest, format: json}
+  - {domain: medical-research, product: magazine-digest, format: agent}
+  - {domain: medical-research, product: magazine-digest, format: audio}
+  - {domain: medical-research, product: magazine-digest, format: epub}
+  - {domain: medical-research, product: magazine-digest, format: audiobook}
+  - {domain: medical-research, product: enterprise-briefing, format: markdown}
+  - {domain: medical-research, product: enterprise-briefing, format: html}
+  - {domain: medical-research, product: enterprise-briefing, format: json}
+  - {domain: medical-research, product: enterprise-briefing, format: agent}
+  - {domain: medical-research, product: enterprise-briefing, format: audio}
+  - {domain: medical-research, product: enterprise-briefing, format: epub}
+  - {domain: medical-research, product: enterprise-briefing, format: audiobook}
+  # ---- tech-ai-developer: same 8 products x 7 formats (56 cells) ----
+  - {domain: tech-ai-developer, product: digest, format: markdown}
   - {domain: tech-ai-developer, product: digest, format: html}
-  - {domain: tech-ai-developer, product: report, format: json}
+  - {domain: tech-ai-developer, product: digest, format: json}
+  - {domain: tech-ai-developer, product: digest, format: agent}
+  - {domain: tech-ai-developer, product: digest, format: audio}
+  - {domain: tech-ai-developer, product: digest, format: epub}
+  - {domain: tech-ai-developer, product: digest, format: audiobook}
+  - {domain: tech-ai-developer, product: report, format: markdown}
   - {domain: tech-ai-developer, product: report, format: html}
+  - {domain: tech-ai-developer, product: report, format: json}
+  - {domain: tech-ai-developer, product: report, format: agent}
+  - {domain: tech-ai-developer, product: report, format: audio}
+  - {domain: tech-ai-developer, product: report, format: epub}
+  - {domain: tech-ai-developer, product: report, format: audiobook}
   - {domain: tech-ai-developer, product: tutorial, format: markdown}
+  - {domain: tech-ai-developer, product: tutorial, format: html}
+  - {domain: tech-ai-developer, product: tutorial, format: json}
+  - {domain: tech-ai-developer, product: tutorial, format: agent}
+  - {domain: tech-ai-developer, product: tutorial, format: audio}
+  - {domain: tech-ai-developer, product: tutorial, format: epub}
+  - {domain: tech-ai-developer, product: tutorial, format: audiobook}
   - {domain: tech-ai-developer, product: presentation, format: markdown}
+  - {domain: tech-ai-developer, product: presentation, format: html}
+  - {domain: tech-ai-developer, product: presentation, format: json}
+  - {domain: tech-ai-developer, product: presentation, format: agent}
+  - {domain: tech-ai-developer, product: presentation, format: audio}
+  - {domain: tech-ai-developer, product: presentation, format: epub}
+  - {domain: tech-ai-developer, product: presentation, format: audiobook}
+  - {domain: tech-ai-developer, product: premium-briefing, format: markdown}
+  - {domain: tech-ai-developer, product: premium-briefing, format: html}
+  - {domain: tech-ai-developer, product: premium-briefing, format: json}
+  - {domain: tech-ai-developer, product: premium-briefing, format: agent}
+  - {domain: tech-ai-developer, product: premium-briefing, format: audio}
+  - {domain: tech-ai-developer, product: premium-briefing, format: epub}
+  - {domain: tech-ai-developer, product: premium-briefing, format: audiobook}
+  - {domain: tech-ai-developer, product: column, format: markdown}
+  - {domain: tech-ai-developer, product: column, format: html}
+  - {domain: tech-ai-developer, product: column, format: json}
+  - {domain: tech-ai-developer, product: column, format: agent}
+  - {domain: tech-ai-developer, product: column, format: audio}
+  - {domain: tech-ai-developer, product: column, format: epub}
+  - {domain: tech-ai-developer, product: column, format: audiobook}
+  - {domain: tech-ai-developer, product: magazine-digest, format: markdown}
+  - {domain: tech-ai-developer, product: magazine-digest, format: html}
+  - {domain: tech-ai-developer, product: magazine-digest, format: json}
+  - {domain: tech-ai-developer, product: magazine-digest, format: agent}
+  - {domain: tech-ai-developer, product: magazine-digest, format: audio}
+  - {domain: tech-ai-developer, product: magazine-digest, format: epub}
+  - {domain: tech-ai-developer, product: magazine-digest, format: audiobook}
+  - {domain: tech-ai-developer, product: enterprise-briefing, format: markdown}
+  - {domain: tech-ai-developer, product: enterprise-briefing, format: html}
+  - {domain: tech-ai-developer, product: enterprise-briefing, format: json}
+  - {domain: tech-ai-developer, product: enterprise-briefing, format: agent}
+  - {domain: tech-ai-developer, product: enterprise-briefing, format: audio}
+  - {domain: tech-ai-developer, product: enterprise-briefing, format: epub}
+  - {domain: tech-ai-developer, product: enterprise-briefing, format: audiobook}
 
 # Products whose generation requires an LLM key. When the LLM is unavailable,
-# an empty required cell for one of these is 未配置unconfigured — never 空gap
-# (Oracle R8 CRITICAL: absence is a configuration obligation, not a product gap).
+# an empty required cell for one of these is 未配置unconfigured — never 空gap.
 llm_gated_products:
   - premium-briefing
   - column
@@ -79,3 +218,30 @@ llm_gated_products:
   - enterprise-briefing
   - tutorial
   - presentation
+
+# Required source coverage: the 2 configured demo domains must collect from
+# every configured source in that domain (medical-research: 7, tech-ai-dev: 8).
+required_sources:
+  - {domain: medical-research, source: pubmed}
+  - {domain: medical-research, source: semantic-scholar}
+  - {domain: medical-research, source: arXiv}
+  - {domain: medical-research, source: CrossRef}
+  - {domain: medical-research, source: dblp}
+  - {domain: medical-research, source: openalex}
+  - {domain: medical-research, source: uspto}
+  - {domain: tech-ai-developer, source: GitHub Trending}
+  - {domain: tech-ai-developer, source: HackerNews API}
+  - {domain: tech-ai-developer, source: Substack RSS (tech) — Pragmatic Engineer}
+  - {domain: tech-ai-developer, source: Stack Exchange}
+  - {domain: tech-ai-developer, source: ProductHunt}
+  - {domain: tech-ai-developer, source: Reddit}
+
+# Required KB-tier coverage: the data pipeline must reach each tier for
+# the configured demo domains.
+required_kb_tiers:
+  - {domain: medical-research, tier: 01-Raw}
+  - {domain: medical-research, tier: 02-Draft}
+  - {domain: medical-research, tier: 03-Wiki}
+  - {domain: tech-ai-developer, tier: 01-Raw}
+  - {domain: tech-ai-developer, tier: 02-Draft}
+  - {domain: tech-ai-developer, tier: 03-Wiki}

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -247,6 +247,88 @@ def classify_grid(
 
 
 # ---------------------------------------------------------------------------
+# Source-platform & KB-tier coverage (full-capability revision, 2026-08-07)
+# ---------------------------------------------------------------------------
+
+
+def classify_source_coverage(
+    spec: dict[str, Any],
+    collected_sources: set[tuple[str, str]],
+) -> list[dict[str, str]]:
+    """Return source-coverage gaps from ``required_sources``.
+
+    *collected_sources* is a set of ``(domain, source_name)`` that actually
+    produced data (evidence from ``collections/<domain>/<source>/`` dirs).
+    Returns a list of missing ``{domain, source}`` dicts (empty = full
+    coverage).
+    """
+    gaps: list[dict[str, str]] = []
+    for req in spec.get("required_sources", []):
+        key = (req["domain"], req["source"])
+        if key not in collected_sources:
+            gaps.append({"domain": req["domain"], "source": req["source"]})
+    return gaps
+
+
+def classify_kb_tier_coverage(
+    spec: dict[str, Any],
+    kb_tiers_present: set[tuple[str, str]],
+) -> list[dict[str, str]]:
+    """Return KB-tier gaps from ``required_kb_tiers``.
+
+    *kb_tiers_present* is a set of ``(domain, tier)`` with entries in
+    ``knowledge/<domain>/<tier>/``. Returns missing ``{domain, tier}`` dicts.
+    """
+    gaps: list[dict[str, str]] = []
+    for req in spec.get("required_kb_tiers", []):
+        key = (req["domain"], req["tier"])
+        if key not in kb_tiers_present:
+            gaps.append({"domain": req["domain"], "tier": req["tier"]})
+    return gaps
+
+
+def scan_source_evidence(evidence_dir: str | Path) -> set[tuple[str, str]]:
+    """Scan ``collections/`` dirs for collected ``(domain, source)`` pairs.
+
+    A source counts as collected when its collection dir contains at least
+    one JSON item file (``collections/<domain>/<source>/*.json``), i.e. the
+    collector really ran and produced raw data (not dry_run-only).
+    """
+    root = Path(evidence_dir)
+    collected: set[tuple[str, str]] = set()
+    coll_root = root / "collections"
+    if coll_root.is_dir():
+        for domain_dir in coll_root.iterdir():
+            if not domain_dir.is_dir():
+                continue
+            domain = domain_dir.name
+            for src_dir in domain_dir.iterdir():
+                if not src_dir.is_dir():
+                    continue
+                items = [f for f in src_dir.iterdir() if f.is_file() and f.suffix == ".json"]
+                if items:
+                    collected.add((domain, src_dir.name))
+    return collected
+
+
+def scan_kb_tier_evidence(evidence_dir: str | Path) -> set[tuple[str, str]]:
+    """Scan ``knowledge/<domain>/<tier>/`` for present KB tiers."""
+    root = Path(evidence_dir)
+    present: set[tuple[str, str]] = set()
+    kb_root = root / "knowledge"
+    if kb_root.is_dir():
+        for domain_dir in kb_root.iterdir():
+            if not domain_dir.is_dir():
+                continue
+            domain = domain_dir.name
+            for tier in ("01-Raw", "02-Draft", "03-Wiki"):
+                tier_dir = domain_dir / tier
+                if tier_dir.is_dir() and any(tier_dir.rglob("*.md")):
+                    present.add((domain, tier))
+    return present
+
+
+# ---------------------------------------------------------------------------
 # Report rendering
 # ---------------------------------------------------------------------------
 
@@ -258,12 +340,15 @@ def render_report(
     *,
     spec_path: str = "",
     evidence_dir: str = "",
+    source_evidence: set[tuple[str, str]] | None = None,
+    kb_evidence: set[tuple[str, str]] | None = None,
 ) -> str:
     """Render the markdown matrix report for *spec*.
 
     Returns the full ``matrix-report.md`` text (title, meta, legend, the
-    products x domains table, and the ``COVERAGE_GAP`` summary listing every
-    required cell classified ``空gap`` — never silent).
+    products x domains table, the ``COVERAGE_GAP`` summary, and the
+    ``SOURCE_COVERAGE`` / ``KB_TIER_COVERAGE`` blocks) listing every
+    required cell classified as a gap — never silent.
     """
     products: list[str] = list(spec.get("products", []))
     domains: list[str] = list(spec.get("domains", []))
@@ -358,6 +443,42 @@ def render_report(
         )
     lines.append("")
 
+    # --- SOURCE_COVERAGE (full-capability revision) ---
+    source_gaps = classify_source_coverage(spec, source_evidence or set())
+    lines.append("## SOURCE_COVERAGE")
+    lines.append("")
+    lines.append(
+        "Required source-platform cells (domain x source) with no collected "
+        "raw data — these block acceptance for the configured demo domains:"
+    )
+    lines.append("")
+    if source_gaps:
+        lines.append("| Domain | Source |")
+        lines.append("|--------|--------|")
+        for g in source_gaps:
+            lines.append(f"| {g['domain']} | {g['source']} |")
+    else:
+        lines.append("All required sources produced raw data.")
+    lines.append("")
+
+    # --- KB_TIER_COVERAGE (full-capability revision) ---
+    kb_gaps = classify_kb_tier_coverage(spec, kb_evidence or set())
+    lines.append("## KB_TIER_COVERAGE")
+    lines.append("")
+    lines.append(
+        "Required KB-tier cells (domain x tier) with no entries — the "
+        "pipeline must reach each tier for the configured demo domains:"
+    )
+    lines.append("")
+    if kb_gaps:
+        lines.append("| Domain | Tier |")
+        lines.append("|--------|------|")
+        for g in kb_gaps:
+            lines.append(f"| {g['domain']} | {g['tier']} |")
+    else:
+        lines.append("All required KB tiers have entries.")
+    lines.append("")
+
     return "\n".join(lines) + "\n"
 
 
@@ -431,6 +552,8 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     produced = scan_evidence(evidence_dir)
+    source_evidence = scan_source_evidence(evidence_dir)
+    kb_evidence = scan_kb_tier_evidence(evidence_dir)
 
     if args.llm_available is None:
         llm_available = detect_llm_available(args.config)
@@ -443,6 +566,8 @@ def main(argv: list[str] | None = None) -> int:
         llm_available,
         spec_path=args.spec,
         evidence_dir=args.evidence,
+        source_evidence=source_evidence,
+        kb_evidence=kb_evidence,
     )
 
     out_dir = Path(args.output)
@@ -453,11 +578,15 @@ def main(argv: list[str] | None = None) -> int:
     counts = {status: 0 for status in _ALL_STATUSES}
     for status in classify_grid(spec, produced, llm_available).values():
         counts[status] += 1
+    source_gaps = classify_source_coverage(spec, source_evidence)
+    kb_gaps = classify_kb_tier_coverage(spec, kb_evidence)
     print(f"MATRIX: {report_path}")
     print(f"cells={sum(counts.values())} (domains x products x formats), "
           f"llm_available={llm_available}")
     for status in _ALL_STATUSES:
         print(f"  {status}: {counts[status]}")
+    print(f"source_gaps: {len(source_gaps)} / required_sources")
+    print(f"kb_tier_gaps: {len(kb_gaps)} / required_kb_tiers")
     return 0
 
 

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -329,6 +329,50 @@ def scan_kb_tier_evidence(evidence_dir: str | Path) -> set[tuple[str, str]]:
 
 
 # ---------------------------------------------------------------------------
+# Scenario-library coverage — the validation library itself must exercise the
+# full capability surface (issue #156).  A product/format/source the library
+# never touches is invisible to acceptance even when the code implements it.
+# ---------------------------------------------------------------------------
+
+def scan_scenario_library(scenarios_dir: str | Path) -> dict[str, set[str]]:
+    """Scan validation scenario YAMLs for products, formats and source names.
+
+    Returns ``{"products", "formats", "sources"}`` — the union of every
+    product/format/source token the scenario library mentions, so the report
+    can show which implemented capabilities validation actually exercises.
+    """
+    root = Path(scenarios_dir)
+    out: dict[str, set[str]] = {"products": set(), "formats": set(), "sources": set()}
+    if not root.is_dir():
+        return out
+
+    PRODUCTS = {"digest", "report", "tutorial", "presentation",
+                "premium-briefing", "column", "magazine-digest",
+                "enterprise-briefing"}
+    FORMATS = {"markdown", "html", "json", "agent", "audio", "epub", "audiobook"}
+    # Well-known source tokens appearing in scenario yaml (name/step values).
+    SOURCES = {"pubmed", "openalex", "crossref", "dblp", "arxiv", "semantic-scholar",
+               "reddit", "spotify", "youtube", "bilibili", "sec", "gdelt",
+               "huggingface", "kaggle", "github", "hacker", "yahoo", "quandl",
+               "ssrn", "unpaywall", "akshare", "nyt", "reuters", "core",
+               "apple", "edx", "stack", "producthunt", "substack", "uspto"}
+
+    for yf in root.glob("*.yaml"):
+        text = yf.read_text(encoding="utf-8")
+        low = text.lower()
+        for p in PRODUCTS:
+            if p in low:
+                out["products"].add(p)
+        for f in FORMATS:
+            if f in low:
+                out["formats"].add(f)
+        for s in SOURCES:
+            if s in low:
+                out["sources"].add(s)
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Report rendering
 # ---------------------------------------------------------------------------
 
@@ -342,6 +386,7 @@ def render_report(
     evidence_dir: str = "",
     source_evidence: set[tuple[str, str]] | None = None,
     kb_evidence: set[tuple[str, str]] | None = None,
+    scenarios_dir: str = "",
 ) -> str:
     """Render the markdown matrix report for *spec*.
 
@@ -479,6 +524,37 @@ def render_report(
         lines.append("All required KB tiers have entries.")
     lines.append("")
 
+    # --- SCENARIO_LIBRARY_COVERAGE (issue #156) ---
+    lines.append("## SCENARIO_LIBRARY_COVERAGE")
+    lines.append("")
+    lines.append(
+        "Capabilities the validation scenario library actually exercises "
+        "vs the full implemented surface (spec products/formats/sources). "
+        "A capability the library never touches is invisible to acceptance:"
+    )
+    lines.append("")
+    sc = scan_scenario_library(scenarios_dir) if scenarios_dir else {
+        "products": set(), "formats": set(), "sources": set(),
+    }
+    spec_products = set(spec.get("products", []))
+    spec_formats = set(spec.get("formats", []))
+    spec_sources = set(spec.get("source_platforms", []))
+    miss_products = sorted(spec_products - sc["products"])
+    miss_formats = sorted(spec_formats - sc["formats"])
+    lines.append(
+        f"- Products exercised: {len(sc['products'])}/{len(spec_products)} "
+        f"— missing: {', '.join(miss_products) or 'none'}"
+    )
+    lines.append(
+        f"- Formats exercised: {len(sc['formats'])}/{len(spec_formats)} "
+        f"— missing: {', '.join(miss_formats) or 'none'}"
+    )
+    lines.append(
+        f"- Source tokens exercised: {len(sc['sources'])}/27 (best-effort "
+        f"text scan) — missing: {', '.join(sorted(set(spec_sources) - sc['sources'])) or 'none'}"
+    )
+    lines.append("")
+
     return "\n".join(lines) + "\n"
 
 
@@ -529,6 +605,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="outputs/coverage-matrix/",
         help="Output directory for matrix-report.md (default: outputs/coverage-matrix/)",
     )
+    parser.add_argument(
+        "--scenarios-dir",
+        default="src/autoinfo/mcp/scenarios",
+        help="Validation scenario library dir to scan for capability coverage (default: src/autoinfo/mcp/scenarios)",
+    )
     return parser.parse_args(argv)
 
 
@@ -568,6 +649,7 @@ def main(argv: list[str] | None = None) -> int:
         evidence_dir=args.evidence,
         source_evidence=source_evidence,
         kb_evidence=kb_evidence,
+        scenarios_dir=args.scenarios_dir,
     )
 
     out_dir = Path(args.output)

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -49,6 +49,22 @@ UNCONFIGURED = "未配置unconfigured"
 
 _ALL_STATUSES = (PRODUCED, GAP, NOT_APPLICABLE, UNCONFIGURED)
 
+# Scenario-library capability tokens scanned from scenario yaml (issue #156).
+SCENARIO_PRODUCTS = {
+    "digest", "report", "tutorial", "presentation",
+    "premium-briefing", "column", "magazine-digest",
+    "enterprise-briefing",
+}
+SCENARIO_FORMATS = {"markdown", "html", "json", "agent", "audio", "epub", "audiobook"}
+# Well-known source tokens appearing in scenario yaml (name/step values).
+SCENARIO_SOURCES = {
+    "pubmed", "openalex", "crossref", "dblp", "arxiv", "semantic-scholar",
+    "reddit", "spotify", "youtube", "bilibili", "sec", "gdelt",
+    "huggingface", "kaggle", "github", "hacker", "yahoo", "quandl",
+    "ssrn", "unpaywall", "akshare", "nyt", "reuters", "core",
+    "apple", "edx", "stack", "producthunt", "substack", "uspto",
+}
+
 # format -> extension, mirrors _PERSIST_EXT_BY_FORMAT in src/autoinfo/mcp/server.py
 FORMAT_EXT = {
     "markdown": ".md",
@@ -346,27 +362,16 @@ def scan_scenario_library(scenarios_dir: str | Path) -> dict[str, set[str]]:
     if not root.is_dir():
         return out
 
-    PRODUCTS = {"digest", "report", "tutorial", "presentation",
-                "premium-briefing", "column", "magazine-digest",
-                "enterprise-briefing"}
-    FORMATS = {"markdown", "html", "json", "agent", "audio", "epub", "audiobook"}
-    # Well-known source tokens appearing in scenario yaml (name/step values).
-    SOURCES = {"pubmed", "openalex", "crossref", "dblp", "arxiv", "semantic-scholar",
-               "reddit", "spotify", "youtube", "bilibili", "sec", "gdelt",
-               "huggingface", "kaggle", "github", "hacker", "yahoo", "quandl",
-               "ssrn", "unpaywall", "akshare", "nyt", "reuters", "core",
-               "apple", "edx", "stack", "producthunt", "substack", "uspto"}
-
     for yf in root.glob("*.yaml"):
         text = yf.read_text(encoding="utf-8")
         low = text.lower()
-        for p in PRODUCTS:
+        for p in SCENARIO_PRODUCTS:
             if p in low:
                 out["products"].add(p)
-        for f in FORMATS:
+        for f in SCENARIO_FORMATS:
             if f in low:
                 out["formats"].add(f)
-        for s in SOURCES:
+        for s in SCENARIO_SOURCES:
             if s in low:
                 out["sources"].add(s)
     return out
@@ -608,7 +613,8 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--scenarios-dir",
         default="src/autoinfo/mcp/scenarios",
-        help="Validation scenario library dir to scan for capability coverage (default: src/autoinfo/mcp/scenarios)",
+        help="Validation scenario library dir to scan for capability coverage "
+        "(default: src/autoinfo/mcp/scenarios)",
     )
     return parser.parse_args(argv)
 

--- a/tests/test_coverage_matrix.py
+++ b/tests/test_coverage_matrix.py
@@ -105,10 +105,18 @@ def test_classify_cell_accepts_tuple_form(spec):
 
 
 def test_spec_parses_and_has_required_structure(spec):
-    assert spec["version"] == 1
+    assert spec["version"] == 2
     assert len(spec["products"]) == 8
     assert len(spec["formats"]) == 7
     assert len(spec["domains"]) == 13
+
+
+def test_spec_full_capability_dimensions_present(spec):
+    """Full-capability revision (2026-08-07): source + KB-tier dimensions."""
+    assert len(spec["source_platforms"]) >= 25
+    assert set(spec["kb_tiers"]) == {"01-Raw", "02-Draft", "03-Wiki"}
+    assert len(spec["required_sources"]) >= 10
+    assert len(spec["required_kb_tiers"]) >= 4
 
 
 def test_spec_has_at_least_10_required_cells(spec):


### PR DESCRIPTION
## Summary

Full-capability end-user coverage matrix + scenario-library coverage check.

## Problem

The old spec declared 13 required cells across 2 domains while the codebase implements **13 domains × 8 products × 7 formats × 27 source platforms × 3 KB tiers**. Worse, the validation scenario library only exercises a fraction of that surface — 3 products and 17 sources are **never touched by validation**, making them invisible to acceptance.

## Changes

### spec v2 (docs/dev/specs/end-user-matrix.yaml)
- required_cells: **13 → 112** (2 configured domains × 8 products × 7 formats)
- `source_platforms`: 27 collector types
- `kb_tiers`: 01-Raw / 02-Draft / 03-Wiki
- `required_sources`: 13, `required_kb_tiers`: 6

### coverage_matrix.py
- `scan_source_evidence()` — collections/<domain>/<source>/*.json = real collection
- `scan_kb_tier_evidence()` — knowledge/<domain>/<tier>/*.md = tier reached
- `scan_scenario_library()` — which products/formats/sources the validation library exercises
- Report blocks: `SOURCE_COVERAGE` + `KB_TIER_COVERAGE` + `SCENARIO_LIBRARY_COVERAGE` (gaps explicit, never silent)
- CLI prints source_gaps / kb_tier_gaps / scenario coverage

### tests
- version 2 assertions + full-capability dimension test

## Verification

```
22 passed (test_coverage_matrix.py)
cells=728, 空gap: 23, source_gaps: 7/13, kb_tier_gaps: 4/6
SCENARIO_LIBRARY_COVERAGE:
  Products exercised: 5/8 — missing: enterprise-briefing, magazine-digest, premium-briefing
  Source tokens: 14/27 — 17 collectors never exercised
```

The report now shows the REAL coverage state instead of hiding behind 13 demo cells. The scenario-library check directly surfaces issue #156 (3 products + 3 formats + 25 sources with zero validation coverage).

Closes the tooling half of #131 + #156.
