### PR TITLE
fix(config): config_to_dict drops fallback base_url/api_key (#155)

### DIFF
--- a/src/autoinfo/config.py
+++ b/src/autoinfo/config.py
@@ -943,18 +943,6 @@ def config_to_dict(config: Config) -> dict[str, Any]:
     # Only include project_name when non-empty (backward compat)
     if config.project.project_name:
         raw["project"]["project_name"] = config.project.project_name
-    # Serialize llm.fallback
-    if config.llm.fallback:
-        raw["llm"]["fallback"] = [
-            {
-                "provider": fb.provider,
-                "model": fb.model,
-                "json_mode": fb.json_mode,
-                "reasoning_model": fb.reasoning_model,
-                "timeout": fb.timeout,
-            }
-            for fb in config.llm.fallback
-        ]
     # Serialize llm.tasks
     if config.llm.tasks:
         raw["llm"]["tasks"] = {}

--- a/tests/test_config_v2.py
+++ b/tests/test_config_v2.py
@@ -596,6 +596,37 @@ class TestDataclassRoundTrip:
         assert d["domains"][0]["search_mode"] == "hybrid"
         assert d["domains"][0]["extract_fields"] == ["title"]
 
+    def test_config_to_dict_preserves_llm_base_url_and_fallback(self) -> None:
+        """#155: save_config must not drop llm.base_url / fallback base_url+api_key.
+
+        Regression: config_to_dict wrote llm.fallback twice — the second pass
+        overwrote the full serialization with a reduced dict that omitted
+        ``base_url`` and ``api_key``, silently wiping them on every save.
+        """
+        original = Config(
+            project=ProjectConfig(name="test", created_at=""),
+            llm=LLMConfig(
+                provider="openai",
+                model="deepseek-v4-flash",
+                api_key="primary-key",
+                base_url="https://opencode.ai/zen/go/v1",
+                fallback=[
+                    LLMConfig(
+                        provider="openai",
+                        model="mimo-v2.5",
+                        api_key="fb-key",
+                        base_url="https://opencode.ai/zen/go/v1",
+                    )
+                ],
+            ),
+        )
+        d = config_to_dict(original)
+        assert d["llm"]["base_url"] == "https://opencode.ai/zen/go/v1"
+        fb = d["llm"]["fallback"][0]
+        assert fb["model"] == "mimo-v2.5"
+        assert fb["base_url"] == "https://opencode.ai/zen/go/v1"
+        assert fb["api_key"] == "fb-key"
+
 
 # ---------------------------------------------------------------------------
 # Validation edge cases


### PR DESCRIPTION
## Summary

Fixes #155 — `save_config()` was silently wiping `llm.fallback` entries' `base_url` and `api_key`.

## Root cause

`config_to_dict` serialized `llm.fallback` twice:
1. Inside the `raw` dict literal — full serialization (provider/model/**base_url**/**api_key**/json_mode/reasoning_model/timeout) ✓
2. A second `if config.llm.fallback:` pass — **overwrote** `raw["llm"]["fallback"]` with a reduced dict **omitting base_url and api_key** ✗

The second pass was redundant and destructive. Removed it; the literal is the single source of truth.

## Verification

- New regression test `test_config_to_dict_preserves_llm_base_url_and_fallback` (fails pre-fix: `fallback[0].base_url=None, api_key=None`; passes post-fix)
- 122 config tests pass (test_config_v2 + test_v1_5_config + test_llm)
- ruff clean