### PR TITLE
test(ci): fix 36 pre-existing CI test-suite failures (#161)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,12 @@ jobs:
   test:
     name: Test suite (fast subset)
     runs-on: ubuntu-latest
+    env:
+      # rich/typer render --help with ANSI escapes that split double-dash
+      # flags (e.g. "--domain" -> "-" + "-domain") when it detects a CI
+      # terminal (GITHUB_ACTIONS=true). TERM=dumb forces plain output so
+      # help-substring assertions pass identically to local runs.
+      TERM: dumb
     # Required job (was continue-on-error in #116). The suite currently carries
     # 12 documented M1-deferred envelope failures (tests/TRIAGE.md rows #73,
     # #74-83, #84) that M1T11-12 clears — read tests/TRIAGE.md before treating
@@ -60,7 +66,7 @@ jobs:
           # and video tests skip via the PIL importorskip in conftest.
           sudo apt-get install -y libpango-1.0-0
       - name: Install package
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,ebook]"
       - name: Run fast test subset
         run: |
           set -o pipefail

--- a/tests/test_cli_v2.py
+++ b/tests/test_cli_v2.py
@@ -7,10 +7,10 @@ logic is tested — the stubs only print ``"not yet implemented"``.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -85,23 +85,40 @@ class TestSourcesCommand:
         assert "--url" in result.stdout
         assert "--type" in result.stdout
 
-    def test_sources_add_requires_domain(self, cli_runner: Any, app: Any) -> None:
+    def test_sources_add_requires_domain(self, cli_runner: Any, app: Any, tmp_path: Path) -> None:
         """``autoinfo sources add`` fails when domain is not configured."""
-        result = cli_runner.invoke(
-            app,
-            [
-                "sources",
-                "add",
-                "--name",
-                "test",
-                "--url",
-                "https://example.com",
-                "--type",
-                "api",
-                "--domain",
-                "test-domain",
-            ],
+        from unittest.mock import patch
+
+        import yaml
+
+        config_dir = tmp_path / ".autoinfo"
+        config_dir.mkdir(exist_ok=True)
+        (config_dir / "config.yaml").write_text(
+            yaml.dump(
+                {
+                    "project": {"name": "T", "created_at": ""},
+                    "llm": {"provider": "openai", "model": "m", "api_key": ""},
+                    "domains": [],
+                }
+            ),
+            encoding="utf-8",
         )
+        with patch("pathlib.Path.cwd", return_value=tmp_path):
+            result = cli_runner.invoke(
+                app,
+                [
+                    "sources",
+                    "add",
+                    "--name",
+                    "test",
+                    "--url",
+                    "https://example.com",
+                    "--type",
+                    "api",
+                    "--domain",
+                    "test-domain",
+                ],
+            )
         assert result.exit_code != 0
         assert "not configured" in result.stderr
 

--- a/tests/test_mcp_v2.py
+++ b/tests/test_mcp_v2.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-import yaml
 from mcp.types import CallToolRequest, CallToolRequestParams, TextContent
 
 from autoinfo.mcp import server as mcp_server
@@ -275,8 +274,18 @@ class TestAddSource:
 class TestAddSources:
     def test_batch_adds_sources(self, tmp_config: Path) -> None:
         sources = [
-            {"name": "src-a", "url": "https://a.example.com", "type": "api", "domain": "medical-research"},
-            {"name": "src-b", "url": "https://b.example.com", "type": "rss", "domain": "medical-research"},
+            {
+                "name": "src-a",
+                "url": "https://a.example.com",
+                "type": "api",
+                "domain": "medical-research",
+            },
+            {
+                "name": "src-b",
+                "url": "https://b.example.com",
+                "type": "rss",
+                "domain": "medical-research",
+            },
         ]
         result = _handle_add_sources(sources=sources)
         assert result["total"] == 2
@@ -597,7 +606,8 @@ class TestNewToolDispatch:
             method="tools/call",
             params=CallToolRequestParams(name="list_domains", arguments={}),
         )
-        result = await handler(request)
+        with _mock_load_config():
+            result = await handler(request)
         data = json.loads(result.root.content[0].text)
         # Envelope shape
         assert data["success"] is True

--- a/tests/test_topic_crud.py
+++ b/tests/test_topic_crud.py
@@ -139,14 +139,20 @@ class TestTopicsAddCLI:
         with patch("pathlib.Path.cwd", return_value=tmp_project):
             cli_runner.invoke(
                 app,
-                ["topics", "add", "--domain", "medical-research", "--name", "IVF", "--keywords", "IVF"],
+                [
+                    "topics", "add", "--domain", "medical-research",
+                    "--name", "IVF", "--keywords", "IVF",
+                ],
                 catch_exceptions=False,
             )
         # Second add (same)
         with patch("pathlib.Path.cwd", return_value=tmp_project):
             result = cli_runner.invoke(
                 app,
-                ["topics", "add", "--domain", "medical-research", "--name", "IVF", "--keywords", "IVF,embryo"],
+                [
+                    "topics", "add", "--domain", "medical-research",
+                    "--name", "IVF", "--keywords", "IVF,embryo",
+                ],
                 catch_exceptions=False,
             )
         assert result.exit_code == 0
@@ -161,11 +167,12 @@ class TestTopicsAddCLI:
 
     def test_add_topic_domain_not_found(self, cli_runner: Any, app: Any, tmp_project: Path) -> None:
         """Adding a topic to a non-existent domain prints an error."""
-        result = cli_runner.invoke(
-            app,
-            ["topics", "add", "--domain", "nonexistent", "--name", "Test", "--keywords", "a"],
-            catch_exceptions=False,
-        )
+        with patch("pathlib.Path.cwd", return_value=tmp_project):
+            result = cli_runner.invoke(
+                app,
+                ["topics", "add", "--domain", "nonexistent", "--name", "Test", "--keywords", "a"],
+                catch_exceptions=False,
+            )
         assert result.exit_code == 1
         assert "not configured" in result.output
 
@@ -192,12 +199,18 @@ class TestTopicsListCLI:
         with patch("pathlib.Path.cwd", return_value=tmp_project):
             cli_runner.invoke(
                 app,
-                ["topics", "add", "--domain", "medical-research", "--name", "IVF", "--keywords", "IVF,embryo"],
+                [
+                    "topics", "add", "--domain", "medical-research",
+                    "--name", "IVF", "--keywords", "IVF,embryo",
+                ],
                 catch_exceptions=False,
             )
             cli_runner.invoke(
                 app,
-                ["topics", "add", "--domain", "medical-research", "--name", "Gene therapy", "--keywords", "CRISPR,gene"],
+                [
+                    "topics", "add", "--domain", "medical-research",
+                    "--name", "Gene therapy", "--keywords", "CRISPR,gene",
+                ],
                 catch_exceptions=False,
             )
 
@@ -222,13 +235,16 @@ class TestTopicsListCLI:
         assert result.exit_code == 0
         assert "No topics configured" in result.stdout
 
-    def test_list_topics_domain_not_found(self, cli_runner: Any, app: Any, tmp_project: Path) -> None:
+    def test_list_topics_domain_not_found(
+        self, cli_runner: Any, app: Any, tmp_project: Path
+    ) -> None:
         """Listing topics for a non-existent domain prints an error."""
-        result = cli_runner.invoke(
-            app,
-            ["topics", "list", "--domain", "nonexistent"],
-            catch_exceptions=False,
-        )
+        with patch("pathlib.Path.cwd", return_value=tmp_project):
+            result = cli_runner.invoke(
+                app,
+                ["topics", "list", "--domain", "nonexistent"],
+                catch_exceptions=False,
+            )
         assert result.exit_code == 1
         assert "not configured" in result.output
 
@@ -252,7 +268,10 @@ class TestTopicsRemoveCLI:
         with patch("pathlib.Path.cwd", return_value=tmp_project):
             cli_runner.invoke(
                 app,
-                ["topics", "add", "--domain", "medical-research", "--name", "IVF", "--keywords", "IVF"],
+                [
+                    "topics", "add", "--domain", "medical-research",
+                    "--name", "IVF", "--keywords", "IVF",
+                ],
                 catch_exceptions=False,
             )
 
@@ -281,13 +300,16 @@ class TestTopicsRemoveCLI:
         assert result.exit_code == 1
         assert "not found" in result.output
 
-    def test_remove_topic_domain_not_found(self, cli_runner: Any, app: Any, tmp_project: Path) -> None:
+    def test_remove_topic_domain_not_found(
+        self, cli_runner: Any, app: Any, tmp_project: Path
+    ) -> None:
         """Removing a topic from a non-existent domain prints an error."""
-        result = cli_runner.invoke(
-            app,
-            ["topics", "remove", "--domain", "nonexistent", "--topic-id", "x"],
-            catch_exceptions=False,
-        )
+        with patch("pathlib.Path.cwd", return_value=tmp_project):
+            result = cli_runner.invoke(
+                app,
+                ["topics", "remove", "--domain", "nonexistent", "--topic-id", "x"],
+                catch_exceptions=False,
+            )
         assert result.exit_code == 1
         assert "not configured" in result.output
 
@@ -311,7 +333,10 @@ class TestMCPAddTopic:
         """Adding a new topic returns created=True and persists it."""
         _setup_minimal_config(tmp_path)
 
-        with patch("autoinfo.mcp.server._config_path", return_value=tmp_path / ".autoinfo" / "config.yaml"):
+        with patch(
+            "autoinfo.mcp.server._config_path",
+            return_value=tmp_path / ".autoinfo" / "config.yaml",
+        ):
             result = _handle_add_topic(
                 domain="medical-research",
                 name="Gene therapy",
@@ -327,9 +352,16 @@ class TestMCPAddTopic:
         """Adding the same topic again returns created=False with existing data."""
         _setup_minimal_config(tmp_path)
 
-        with patch("autoinfo.mcp.server._config_path", return_value=tmp_path / ".autoinfo" / "config.yaml"):
-            result1 = _handle_add_topic(domain="medical-research", name="Gene therapy", keywords=["CRISPR"])
-            result2 = _handle_add_topic(domain="medical-research", name="Gene therapy", keywords=["different"])
+        with patch(
+            "autoinfo.mcp.server._config_path",
+            return_value=tmp_path / ".autoinfo" / "config.yaml",
+        ):
+            result1 = _handle_add_topic(
+                domain="medical-research", name="Gene therapy", keywords=["CRISPR"]
+            )
+            result2 = _handle_add_topic(
+                domain="medical-research", name="Gene therapy", keywords=["different"]
+            )
 
         assert result1["created"] is True
         assert result2["created"] is False
@@ -340,14 +372,20 @@ class TestMCPAddTopic:
         """Adding to a non-existent domain returns DomainNotFound error."""
         _setup_minimal_config(tmp_path)
 
-        with patch("autoinfo.mcp.server._config_path", return_value=tmp_path / ".autoinfo" / "config.yaml"):
+        with patch(
+            "autoinfo.mcp.server._config_path",
+            return_value=tmp_path / ".autoinfo" / "config.yaml",
+        ):
             result = _handle_add_topic(domain="nonexistent", name="Test")
 
         assert result["error_code"] == "DomainNotFound"
 
     def test_no_config_returns_error(self, tmp_path: Path) -> None:
         """When no config file exists, returns an error dict."""
-        with patch("autoinfo.mcp.server._config_path", return_value=tmp_path / ".autoinfo" / "config.yaml"):
+        with patch(
+            "autoinfo.mcp.server._config_path",
+            return_value=tmp_path / ".autoinfo" / "config.yaml",
+        ):
             result = _handle_add_topic(domain="medical-research", name="Test")
 
         assert "error_code" in result
@@ -363,7 +401,10 @@ class TestMCPRemoveTopic:
         """Removing an existing topic returns removed=True."""
         _setup_config_with_topics(tmp_path)
 
-        with patch("autoinfo.mcp.server._config_path", return_value=tmp_path / ".autoinfo" / "config.yaml"):
+        with patch(
+            "autoinfo.mcp.server._config_path",
+            return_value=tmp_path / ".autoinfo" / "config.yaml",
+        ):
             result = _handle_remove_topic(domain="medical-research", topic_id="IVF")
 
         assert result["removed"] is True
@@ -373,7 +414,10 @@ class TestMCPRemoveTopic:
         """Removing a non-existent topic returns TopicNotFound error."""
         _setup_config_with_topics(tmp_path)
 
-        with patch("autoinfo.mcp.server._config_path", return_value=tmp_path / ".autoinfo" / "config.yaml"):
+        with patch(
+            "autoinfo.mcp.server._config_path",
+            return_value=tmp_path / ".autoinfo" / "config.yaml",
+        ):
             result = _handle_remove_topic(domain="medical-research", topic_id="nonexistent")
 
         assert result["error_code"] == "TopicNotFound"
@@ -382,14 +426,20 @@ class TestMCPRemoveTopic:
         """Removing from a non-existent domain returns DomainNotFound error."""
         _setup_config_with_topics(tmp_path)
 
-        with patch("autoinfo.mcp.server._config_path", return_value=tmp_path / ".autoinfo" / "config.yaml"):
+        with patch(
+            "autoinfo.mcp.server._config_path",
+            return_value=tmp_path / ".autoinfo" / "config.yaml",
+        ):
             result = _handle_remove_topic(domain="nonexistent", topic_id="IVF")
 
         assert result["error_code"] == "DomainNotFound"
 
     def test_no_config_returns_error(self, tmp_path: Path) -> None:
         """When no config file exists, returns an error dict."""
-        with patch("autoinfo.mcp.server._config_path", return_value=tmp_path / ".autoinfo" / "config.yaml"):
+        with patch(
+            "autoinfo.mcp.server._config_path",
+            return_value=tmp_path / ".autoinfo" / "config.yaml",
+        ):
             result = _handle_remove_topic(domain="medical-research", topic_id="IVF")
 
         assert "error_code" in result
@@ -405,7 +455,10 @@ class TestMCPListTopics:
         """Listing topics returns all topics for the domain."""
         _setup_config_with_topics(tmp_path)
 
-        with patch("autoinfo.mcp.server._config_path", return_value=tmp_path / ".autoinfo" / "config.yaml"):
+        with patch(
+            "autoinfo.mcp.server._config_path",
+            return_value=tmp_path / ".autoinfo" / "config.yaml",
+        ):
             result = _handle_list_topics(domain="medical-research")
 
         assert result["count"] == 2
@@ -417,7 +470,10 @@ class TestMCPListTopics:
         """Domain with no topics returns an empty list."""
         _setup_minimal_config(tmp_path)
 
-        with patch("autoinfo.mcp.server._config_path", return_value=tmp_path / ".autoinfo" / "config.yaml"):
+        with patch(
+            "autoinfo.mcp.server._config_path",
+            return_value=tmp_path / ".autoinfo" / "config.yaml",
+        ):
             result = _handle_list_topics(domain="medical-research")
 
         assert result["count"] == 0
@@ -427,14 +483,20 @@ class TestMCPListTopics:
         """Listing topics for a non-existent domain returns DomainNotFound."""
         _setup_minimal_config(tmp_path)
 
-        with patch("autoinfo.mcp.server._config_path", return_value=tmp_path / ".autoinfo" / "config.yaml"):
+        with patch(
+            "autoinfo.mcp.server._config_path",
+            return_value=tmp_path / ".autoinfo" / "config.yaml",
+        ):
             result = _handle_list_topics(domain="nonexistent")
 
         assert result["error_code"] == "DomainNotFound"
 
     def test_no_config_returns_error(self, tmp_path: Path) -> None:
         """When no config file exists, returns an error dict."""
-        with patch("autoinfo.mcp.server._config_path", return_value=tmp_path / ".autoinfo" / "config.yaml"):
+        with patch(
+            "autoinfo.mcp.server._config_path",
+            return_value=tmp_path / ".autoinfo" / "config.yaml",
+        ):
             result = _handle_list_topics(domain="medical-research")
 
         assert "error_code" in result
@@ -511,7 +573,12 @@ def _setup_minimal_config(tmp_path: Path) -> None:
                 "name": "medical-research",
                 "active": True,
                 "sources": [
-                    {"name": "pubmed", "type": "api", "url": "https://pubmed.ncbi.nlm.nih.gov/", "quality_tier": 1},
+                    {
+                        "name": "pubmed",
+                        "type": "api",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/",
+                        "quality_tier": 1,
+                    },
                 ],
                 "topics": [],
             },
@@ -535,7 +602,12 @@ def _setup_config_with_topics(tmp_path: Path) -> None:
                 "name": "medical-research",
                 "active": True,
                 "sources": [
-                    {"name": "pubmed", "type": "api", "url": "https://pubmed.ncbi.nlm.nih.gov/", "quality_tier": 1},
+                    {
+                        "name": "pubmed",
+                        "type": "api",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/",
+                        "quality_tier": 1,
+                    },
                 ],
                 "topics": [
                     {"name": "IVF", "keywords": ["IVF", "embryo"]},


### PR DESCRIPTION
## Summary

Fixes #161 — the CI `Test suite (fast subset)` job is red on `main` with 36 pre-existing failures across 3 independent root causes. This PR makes the CI test suite green.

## Root causes & fixes

### 1. ebooklib missing in CI (5 tests) — `test_output_ebook.py`
`ci.yml` installed only `.[dev]`; the EPUB round-trip tests genuinely require the `ebook` extra (nightly.yml already installed it). Fix: install `.[dev,ebook]`.

### 2. rich/ANSI `--help` rendering (27 tests)
Typer/rich emits ANSI escapes that split double-dash flags — `--domain` renders as `-` + `-domain` with a reset code between — when it detects a CI terminal (`GITHUB_ACTIONS=true`). Fix: set `TERM: dumb` on the CI test job so help assertions see the same plain output as local runs.

### 3. Config-seam tests (4 tests)
`test_topic_crud.py` (3× domain_not_found), `test_cli_v2.py` (test_sources_add_requires_domain), `test_mcp_v2.py` (test_list_domains_dispatches) depended on the ambient cwd config that exists in local dev but not in a fresh CI checkout. Fix: patch `pathlib.Path.cwd` to a tmp config (topic_crud/cli_v2) or use the existing `_mock_load_config` seam (mcp_v2) — same hermetic pattern as #117.

Also clears pre-existing ruff debt (E501 ×N, F401, import order) in the three touched test files so the changed-file lint gate passes.

## Verification

- All 36 previously-failing tests pass locally under CI-hermetic conditions (`GITHUB_ACTIONS=true TERM=dumb`, no config): 230 passed
- Broader regression: 335 passed, 1 skipped across all CLI-adjacent files
- ruff clean on all changed files