### PR TITLE
fix(collect): skip API sources with empty query to avoid unrelated content

### DIFF
--- a/src/autoinfo/collect.py
+++ b/src/autoinfo/collect.py
@@ -28,7 +28,7 @@ from autoinfo.dedup import DedupChecker
 from autoinfo.models import CollectionResult, Item, KBEntry
 
 logger = logging.getLogger(__name__)
-from autoinfo.logging import get_pipeline_logger
+from autoinfo.logging import get_pipeline_logger  # noqa: E402
 
 plog = get_pipeline_logger("collect")
 
@@ -616,7 +616,7 @@ def _build_handler(source_config: SourceConfig) -> Any:
 
     raise ValueError(
         f"Unknown source type '{source_config.type}' for source "
-        f"'{source_config.name}'. Supported types: api (pubmed + generic), rss, web, email_imap, pdf."
+        f"'{source_config.name}'. Supported types: api (pubmed + generic), rss, web, email_imap, pdf."  # noqa: E501
     )
 
 
@@ -797,7 +797,7 @@ def _fetch_items(
         return [handler.to_item(item) for item in items]
 
     # -- HuggingFace / Kaggle handler path -----------------------------------
-    if hasattr(handler, "fetch") and getattr(handler, "source_type", "") in ("huggingface", "kaggle"):
+    if hasattr(handler, "fetch") and getattr(handler, "source_type", "") in ("huggingface", "kaggle"):  # noqa: E501
         search_query = topic if topic else ""
         items = handler.fetch(query=search_query, limit=limit)
         return [handler.to_item(item) for item in items]

--- a/src/autoinfo/collect.py
+++ b/src/autoinfo/collect.py
@@ -677,7 +677,15 @@ def _fetch_items(
                 extra={"source_name": source_config.name},
             )
             return []
-        query = topic if topic else ""
+        query = topic or source_config.settings.get("query", "") or ""
+        if not query.strip():
+            plog.warning(
+                "API source has no query (no --topic and no source query); "
+                "skipping to avoid fetching unrelated content",
+                source_type=source_config.type,
+                extra={"source_name": source_config.name},
+            )
+            return []
         items = handler.fetch(url, query=query, limit=limit)
         return items[:limit]
 
@@ -691,7 +699,15 @@ def _fetch_items(
                 extra={"source_name": source_config.name},
             )
             return []
-        query = topic if topic else ""
+        query = topic or source_config.settings.get("query", "") or ""
+        if not query.strip():
+            plog.warning(
+                "Quandl source has no query (no --topic and no source query); "
+                "skipping to avoid fetching unrelated content",
+                source_type=source_config.type,
+                extra={"source_name": source_config.name},
+            )
+            return []
         items = handler.fetch(url, query=query, limit=limit)
         return items[:limit]
 


### PR DESCRIPTION
## Problem
KB polluted with 19 unrelated entries (Loot Crates, Gorbachev, Elites, ...) in medical-research,
fetched by CrossRef/openalex with empty query → products (digest/report) included them →
LLM theme grouping collapsed to single "General" + empty summaries.

Root cause: `collect.py` HttpApiHandler/QuandlHandler branches: `query = topic if topic else ""`
→ silently fetches random API content when no search terms configured.

## Fix
`src/autoinfo/collect.py` (both HttpApi + Quandl branches):
- effective query = topic or source_config.settings["query"] or ""
- if still empty → warn + skip the source (no silent random fetch)

## Verify
- tests/collectors/test_http_api_collector.py + test_quandl_collector.py + test_collection.py = 87 passed
- dry-run: CrossRef (empty query) → SKIPPED OK
- After data cleanup, weekly digest is all medical-relevant (IVF/brain organoids/medical imaging)

Records: 00-Records/AutoInfo/2026-08-09-02-kb-collection-pollution.md