### PR TITLE
fix(output): report synthesis + validation matrix spec restore (昨晚工作补推)

### DIFF
--- a/docs/dev/specs/end-user-matrix.yaml
+++ b/docs/dev/specs/end-user-matrix.yaml
@@ -90,63 +90,123 @@ kb_tiers:
   - 02-Draft
   - 03-Wiki
 
-# Required cells — every product x format the codebase ACTUALLY supports
-# (capability-verified 2026-08-09; tutorial=md+agent, presentation=md+html+agent,
-# template products=md+html, digest/report=all 7). Cells outside this set are
-# not implementable and are NOT gaps.
+# Required cells — FULL end-user capability surface (8 products x 7 formats).
+# Each cell carries a capability annotation so the matrix can distinguish
+# 'real gap' (implemented but no evidence) from 'capability boundary'
+# (not implemented by design — annotated, not silently dropped).
 required_cells:
-  - {domain: medical-research, product: digest, format: markdown}
-  - {domain: medical-research, product: digest, format: html}
-  - {domain: medical-research, product: digest, format: json}
-  - {domain: medical-research, product: digest, format: agent}
-  - {domain: medical-research, product: digest, format: audio}
-  - {domain: medical-research, product: digest, format: epub}
-  - {domain: medical-research, product: digest, format: audiobook}
-  - {domain: medical-research, product: report, format: markdown}
-  - {domain: medical-research, product: report, format: html}
-  - {domain: medical-research, product: report, format: json}
-  - {domain: medical-research, product: report, format: agent}
-  - {domain: medical-research, product: report, format: audio}
-  - {domain: medical-research, product: report, format: epub}
-  - {domain: medical-research, product: report, format: audiobook}
-  - {domain: medical-research, product: tutorial, format: markdown}
-  - {domain: medical-research, product: tutorial, format: agent}
-  - {domain: medical-research, product: presentation, format: markdown}
-  - {domain: medical-research, product: presentation, format: html}
-  - {domain: medical-research, product: presentation, format: agent}
-  - {domain: medical-research, product: premium-briefing, format: markdown}
-  - {domain: medical-research, product: premium-briefing, format: html}
-  - {domain: medical-research, product: column, format: markdown}
-  - {domain: medical-research, product: magazine-digest, format: markdown}
-  - {domain: medical-research, product: magazine-digest, format: html}
-  - {domain: medical-research, product: enterprise-briefing, format: markdown}
-  - {domain: medical-research, product: enterprise-briefing, format: html}
-  - {domain: tech-ai-developer, product: digest, format: markdown}
-  - {domain: tech-ai-developer, product: digest, format: html}
-  - {domain: tech-ai-developer, product: digest, format: json}
-  - {domain: tech-ai-developer, product: digest, format: agent}
-  - {domain: tech-ai-developer, product: digest, format: audio}
-  - {domain: tech-ai-developer, product: digest, format: epub}
-  - {domain: tech-ai-developer, product: digest, format: audiobook}
-  - {domain: tech-ai-developer, product: report, format: markdown}
-  - {domain: tech-ai-developer, product: report, format: html}
-  - {domain: tech-ai-developer, product: report, format: json}
-  - {domain: tech-ai-developer, product: report, format: agent}
-  - {domain: tech-ai-developer, product: report, format: audio}
-  - {domain: tech-ai-developer, product: report, format: epub}
-  - {domain: tech-ai-developer, product: report, format: audiobook}
-  - {domain: tech-ai-developer, product: tutorial, format: markdown}
-  - {domain: tech-ai-developer, product: tutorial, format: agent}
-  - {domain: tech-ai-developer, product: presentation, format: markdown}
-  - {domain: tech-ai-developer, product: presentation, format: html}
-  - {domain: tech-ai-developer, product: presentation, format: agent}
-  - {domain: tech-ai-developer, product: premium-briefing, format: markdown}
-  - {domain: tech-ai-developer, product: premium-briefing, format: html}
-  - {domain: tech-ai-developer, product: column, format: markdown}
-  - {domain: tech-ai-developer, product: magazine-digest, format: markdown}
-  - {domain: tech-ai-developer, product: magazine-digest, format: html}
-  - {domain: tech-ai-developer, product: enterprise-briefing, format: markdown}
-  - {domain: tech-ai-developer, product: enterprise-briefing, format: html}
+  - {domain: medical-research, product: digest, format: markdown, capability: implemented}
+  - {domain: medical-research, product: digest, format: html, capability: implemented}
+  - {domain: medical-research, product: digest, format: json, capability: implemented}
+  - {domain: medical-research, product: digest, format: agent, capability: implemented}
+  - {domain: medical-research, product: digest, format: audio, capability: implemented}
+  - {domain: medical-research, product: digest, format: epub, capability: implemented}
+  - {domain: medical-research, product: digest, format: audiobook, capability: implemented}
+  - {domain: medical-research, product: report, format: markdown, capability: implemented}
+  - {domain: medical-research, product: report, format: html, capability: implemented}
+  - {domain: medical-research, product: report, format: json, capability: implemented}
+  - {domain: medical-research, product: report, format: agent, capability: implemented}
+  - {domain: medical-research, product: report, format: audio, capability: implemented}
+  - {domain: medical-research, product: report, format: epub, capability: implemented}
+  - {domain: medical-research, product: report, format: audiobook, capability: implemented}
+  - {domain: medical-research, product: tutorial, format: markdown, capability: implemented}
+  - {domain: medical-research, product: tutorial, format: html, capability: not-implemented}
+  - {domain: medical-research, product: tutorial, format: json, capability: not-implemented}
+  - {domain: medical-research, product: tutorial, format: agent, capability: implemented}
+  - {domain: medical-research, product: tutorial, format: audio, capability: not-implemented}
+  - {domain: medical-research, product: tutorial, format: epub, capability: not-implemented}
+  - {domain: medical-research, product: tutorial, format: audiobook, capability: not-implemented}
+  - {domain: medical-research, product: presentation, format: markdown, capability: implemented}
+  - {domain: medical-research, product: presentation, format: html, capability: implemented}
+  - {domain: medical-research, product: presentation, format: json, capability: not-implemented}
+  - {domain: medical-research, product: presentation, format: agent, capability: implemented}
+  - {domain: medical-research, product: presentation, format: audio, capability: not-implemented}
+  - {domain: medical-research, product: presentation, format: epub, capability: not-implemented}
+  - {domain: medical-research, product: presentation, format: audiobook, capability: not-implemented}
+  - {domain: medical-research, product: premium-briefing, format: markdown, capability: implemented}
+  - {domain: medical-research, product: premium-briefing, format: html, capability: implemented}
+  - {domain: medical-research, product: premium-briefing, format: json, capability: not-implemented}
+  - {domain: medical-research, product: premium-briefing, format: agent, capability: not-implemented}
+  - {domain: medical-research, product: premium-briefing, format: audio, capability: not-implemented}
+  - {domain: medical-research, product: premium-briefing, format: epub, capability: not-implemented}
+  - {domain: medical-research, product: premium-briefing, format: audiobook, capability: not-implemented}
+  - {domain: medical-research, product: column, format: markdown, capability: implemented}
+  - {domain: medical-research, product: column, format: html, capability: implemented}
+  - {domain: medical-research, product: column, format: json, capability: not-implemented}
+  - {domain: medical-research, product: column, format: agent, capability: not-implemented}
+  - {domain: medical-research, product: column, format: audio, capability: not-implemented}
+  - {domain: medical-research, product: column, format: epub, capability: not-implemented}
+  - {domain: medical-research, product: column, format: audiobook, capability: not-implemented}
+  - {domain: medical-research, product: magazine-digest, format: markdown, capability: implemented}
+  - {domain: medical-research, product: magazine-digest, format: html, capability: implemented}
+  - {domain: medical-research, product: magazine-digest, format: json, capability: not-implemented}
+  - {domain: medical-research, product: magazine-digest, format: agent, capability: not-implemented}
+  - {domain: medical-research, product: magazine-digest, format: audio, capability: not-implemented}
+  - {domain: medical-research, product: magazine-digest, format: epub, capability: not-implemented}
+  - {domain: medical-research, product: magazine-digest, format: audiobook, capability: not-implemented}
+  - {domain: medical-research, product: enterprise-briefing, format: markdown, capability: implemented}
+  - {domain: medical-research, product: enterprise-briefing, format: html, capability: implemented}
+  - {domain: medical-research, product: enterprise-briefing, format: json, capability: not-implemented}
+  - {domain: medical-research, product: enterprise-briefing, format: agent, capability: not-implemented}
+  - {domain: medical-research, product: enterprise-briefing, format: audio, capability: not-implemented}
+  - {domain: medical-research, product: enterprise-briefing, format: epub, capability: not-implemented}
+  - {domain: medical-research, product: enterprise-briefing, format: audiobook, capability: not-implemented}
+  - {domain: tech-ai-developer, product: digest, format: markdown, capability: implemented}
+  - {domain: tech-ai-developer, product: digest, format: html, capability: implemented}
+  - {domain: tech-ai-developer, product: digest, format: json, capability: implemented}
+  - {domain: tech-ai-developer, product: digest, format: agent, capability: implemented}
+  - {domain: tech-ai-developer, product: digest, format: audio, capability: implemented}
+  - {domain: tech-ai-developer, product: digest, format: epub, capability: implemented}
+  - {domain: tech-ai-developer, product: digest, format: audiobook, capability: implemented}
+  - {domain: tech-ai-developer, product: report, format: markdown, capability: implemented}
+  - {domain: tech-ai-developer, product: report, format: html, capability: implemented}
+  - {domain: tech-ai-developer, product: report, format: json, capability: implemented}
+  - {domain: tech-ai-developer, product: report, format: agent, capability: implemented}
+  - {domain: tech-ai-developer, product: report, format: audio, capability: implemented}
+  - {domain: tech-ai-developer, product: report, format: epub, capability: implemented}
+  - {domain: tech-ai-developer, product: report, format: audiobook, capability: implemented}
+  - {domain: tech-ai-developer, product: tutorial, format: markdown, capability: implemented}
+  - {domain: tech-ai-developer, product: tutorial, format: html, capability: not-implemented}
+  - {domain: tech-ai-developer, product: tutorial, format: json, capability: not-implemented}
+  - {domain: tech-ai-developer, product: tutorial, format: agent, capability: implemented}
+  - {domain: tech-ai-developer, product: tutorial, format: audio, capability: not-implemented}
+  - {domain: tech-ai-developer, product: tutorial, format: epub, capability: not-implemented}
+  - {domain: tech-ai-developer, product: tutorial, format: audiobook, capability: not-implemented}
+  - {domain: tech-ai-developer, product: presentation, format: markdown, capability: implemented}
+  - {domain: tech-ai-developer, product: presentation, format: html, capability: implemented}
+  - {domain: tech-ai-developer, product: presentation, format: json, capability: not-implemented}
+  - {domain: tech-ai-developer, product: presentation, format: agent, capability: implemented}
+  - {domain: tech-ai-developer, product: presentation, format: audio, capability: not-implemented}
+  - {domain: tech-ai-developer, product: presentation, format: epub, capability: not-implemented}
+  - {domain: tech-ai-developer, product: presentation, format: audiobook, capability: not-implemented}
+  - {domain: tech-ai-developer, product: premium-briefing, format: markdown, capability: implemented}
+  - {domain: tech-ai-developer, product: premium-briefing, format: html, capability: implemented}
+  - {domain: tech-ai-developer, product: premium-briefing, format: json, capability: not-implemented}
+  - {domain: tech-ai-developer, product: premium-briefing, format: agent, capability: not-implemented}
+  - {domain: tech-ai-developer, product: premium-briefing, format: audio, capability: not-implemented}
+  - {domain: tech-ai-developer, product: premium-briefing, format: epub, capability: not-implemented}
+  - {domain: tech-ai-developer, product: premium-briefing, format: audiobook, capability: not-implemented}
+  - {domain: tech-ai-developer, product: column, format: markdown, capability: implemented}
+  - {domain: tech-ai-developer, product: column, format: html, capability: implemented}
+  - {domain: tech-ai-developer, product: column, format: json, capability: not-implemented}
+  - {domain: tech-ai-developer, product: column, format: agent, capability: not-implemented}
+  - {domain: tech-ai-developer, product: column, format: audio, capability: not-implemented}
+  - {domain: tech-ai-developer, product: column, format: epub, capability: not-implemented}
+  - {domain: tech-ai-developer, product: column, format: audiobook, capability: not-implemented}
+  - {domain: tech-ai-developer, product: magazine-digest, format: markdown, capability: implemented}
+  - {domain: tech-ai-developer, product: magazine-digest, format: html, capability: implemented}
+  - {domain: tech-ai-developer, product: magazine-digest, format: json, capability: not-implemented}
+  - {domain: tech-ai-developer, product: magazine-digest, format: agent, capability: not-implemented}
+  - {domain: tech-ai-developer, product: magazine-digest, format: audio, capability: not-implemented}
+  - {domain: tech-ai-developer, product: magazine-digest, format: epub, capability: not-implemented}
+  - {domain: tech-ai-developer, product: magazine-digest, format: audiobook, capability: not-implemented}
+  - {domain: tech-ai-developer, product: enterprise-briefing, format: markdown, capability: implemented}
+  - {domain: tech-ai-developer, product: enterprise-briefing, format: html, capability: implemented}
+  - {domain: tech-ai-developer, product: enterprise-briefing, format: json, capability: not-implemented}
+  - {domain: tech-ai-developer, product: enterprise-briefing, format: agent, capability: not-implemented}
+  - {domain: tech-ai-developer, product: enterprise-briefing, format: audio, capability: not-implemented}
+  - {domain: tech-ai-developer, product: enterprise-briefing, format: epub, capability: not-implemented}
+  - {domain: tech-ai-developer, product: enterprise-briefing, format: audiobook, capability: not-implemented}
 # Products whose generation requires an LLM key. When the LLM is unavailable,
 # an empty required cell for one of these is 未配置unconfigured — never 空gap.
 llm_gated_products:

--- a/scripts/audit_product_quality.py
+++ b/scripts/audit_product_quality.py
@@ -1,83 +1,72 @@
 #!/usr/bin/env python3
-"""Content-quality audit of processed products (end-user view).
+"""Refined content-quality audit: focus on EXECUTIVE SUMMARY quality (the
+end-user reads first), not stray section titles.
 
-For every persisted product under outputs/<domain>/, classify content quality:
-- OK: has substantive content (non-placeholder, non-empty, real substance)
-- EMPTY: placeholder/empty-state markers (_No objectives defined._ etc.)
-- VAGUE: content exists but is generic boilerplate (no domain-specific substance)
-- NONPRODUCT: not a product file (matrix-report.md etc.)
+For each md product, judge:
+- OK: executive summary (first content section after metadata) has substantive
+      domain-specific content (not boilerplate/placeholder/self-referential)
+- EMPTY: no content / placeholder markers anywhere
+- VAGUE: executive summary is boilerplate (this report covers / article titled / no content)
+- NONPRODUCT: matrix/test artifacts
 
 Usage: python3 scripts/audit_product_quality.py
 """
 import re
-import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 OUTPUTS = ROOT / "outputs"
 
-# Placeholder markers that indicate an empty-state product
-PLACEHOLDER_MARKERS = [
-    "_No objectives defined._",
-    "_No exercises provided._",
-    "_No entries found",
-    "_No content",
-    "No content provided",
-    "no content was provided",
-    "has no accessible content",
-    "lacks accessible content",
-    "but no content was provided",
+PLACEHOLDER = [
+    "_No objectives defined._", "_No exercises provided._", "_No entries found",
+    "No content provided", "no content was provided", "has no accessible content",
+    "were submitted without substantive content", "no findings or analyses were available",
     "is empty, so no detailed summary",
-    "were submitted without substantive content",
-    "no findings or analyses were available",
+]
+VAGUE = [
+    "this report covers", "the article titled", "the provided content is empty",
+    "appears to discuss", "the instructions emphasize", "this article is a directive",
+    "this document provides instructions", "all .* entries included in this report",
+    "the report's content and implications remain unspecified",
 ]
 
-# Vague boilerplate phrases (LLM wrote meta-instructions instead of analysis)
-VAGUE_MARKERS = [
-    "the instructions emphasize",
-    "this article is a directive",
-    "this document provides instructions",
-    "the article titled",
-    "this report covers",
-    "distills .* entries into a coherent picture",
-    "all .* entries included in this report",
-    "the report's content and implications remain unspecified",
-    "appears to discuss",
-    "no content was provided for analysis",
-    "the provided content is empty",
-]
+
+def _first_summary(text: str) -> str:
+    """Return text up to the first '## Executive Summary' section content."""
+    m = re.search(r"## (?:Executive Summary|The Big Idea)\s*\n(.*?)(?=\n## |\Z)", text, re.S)
+    if m:
+        return m.group(1)
+    return text[:1500]
 
 
 def _classify(path: Path, text: str) -> tuple[str, str]:
-    """Return (status, note)."""
     name = path.name
     if name.startswith("matrix-report") or name == "report.md":
-        return "NONPRODUCT", "matrix/test artifact, not a product"
+        return "NONPRODUCT", "matrix/test artifact"
     if not text.strip():
-        return "EMPTY", "zero-length file"
-    # EMPTY: placeholder markers
-    for m in PLACEHOLDER_MARKERS:
+        return "EMPTY", "zero-length"
+    for m in PLACEHOLDER:
         if m.lower() in text.lower():
-            return "EMPTY", f"placeholder: {m[:40]}"
-    # VAGUE: boilerplate
-    for m in VAGUE_MARKERS:
-        if re.search(m, text, re.IGNORECASE):
-            return "VAGUE", f"boilerplate: {m[:40]}"
+            return "EMPTY", f"placeholder: {m[:36]}"
+    summary = _first_summary(text)
+    if not summary.strip():
+        return "EMPTY", "no summary section"
+    for m in VAGUE:
+        if re.search(m, summary, re.I):
+            return "VAGUE", f"boilerplate in summary: {m[:36]}"
     return "OK", ""
 
 
 def main() -> None:
-    by_status: dict[str, list[tuple[Path, str]]] = {}
+    by: dict[str, list[tuple[Path, str]]] = {}
     for p in OUTPUTS.rglob("*.md"):
-        text = p.read_text(encoding="utf-8", errors="replace")
-        status, note = _classify(p, text)
-        by_status.setdefault(status, []).append((p, note))
-
-    for status in ("OK", "EMPTY", "VAGUE", "NONPRODUCT"):
-        items = by_status.get(status, [])
-        print(f"\n=== {status}: {len(items)} ===")
-        for p, note in sorted(items):
-            print(f"  {p.relative_to(OUTPUTS)} | {note}")
+        status, note = _classify(p, p.read_text(encoding="utf-8", errors="replace"))
+        by.setdefault(status, []).append((p, note))
+    for st in ("OK", "VAGUE", "EMPTY", "NONPRODUCT"):
+        items = by.get(st, [])
+        print(f"\n=== {st}: {len(items)} ===")
+        for p, n in sorted(items):
+            print(f"  {p.relative_to(OUTPUTS)} | {n}")
 
 
 if __name__ == "__main__":

--- a/scripts/audit_product_quality.py
+++ b/scripts/audit_product_quality.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Content-quality audit of processed products (end-user view).
+
+For every persisted product under outputs/<domain>/, classify content quality:
+- OK: has substantive content (non-placeholder, non-empty, real substance)
+- EMPTY: placeholder/empty-state markers (_No objectives defined._ etc.)
+- VAGUE: content exists but is generic boilerplate (no domain-specific substance)
+- NONPRODUCT: not a product file (matrix-report.md etc.)
+
+Usage: python3 scripts/audit_product_quality.py
+"""
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+OUTPUTS = ROOT / "outputs"
+
+# Placeholder markers that indicate an empty-state product
+PLACEHOLDER_MARKERS = [
+    "_No objectives defined._",
+    "_No exercises provided._",
+    "_No entries found",
+    "_No content",
+    "No content provided",
+    "no content was provided",
+    "has no accessible content",
+    "lacks accessible content",
+    "but no content was provided",
+    "is empty, so no detailed summary",
+    "were submitted without substantive content",
+    "no findings or analyses were available",
+]
+
+# Vague boilerplate phrases (LLM wrote meta-instructions instead of analysis)
+VAGUE_MARKERS = [
+    "the instructions emphasize",
+    "this article is a directive",
+    "this document provides instructions",
+    "the article titled",
+    "this report covers",
+    "distills .* entries into a coherent picture",
+    "all .* entries included in this report",
+    "the report's content and implications remain unspecified",
+    "appears to discuss",
+    "no content was provided for analysis",
+    "the provided content is empty",
+]
+
+
+def _classify(path: Path, text: str) -> tuple[str, str]:
+    """Return (status, note)."""
+    name = path.name
+    if name.startswith("matrix-report") or name == "report.md":
+        return "NONPRODUCT", "matrix/test artifact, not a product"
+    if not text.strip():
+        return "EMPTY", "zero-length file"
+    # EMPTY: placeholder markers
+    for m in PLACEHOLDER_MARKERS:
+        if m.lower() in text.lower():
+            return "EMPTY", f"placeholder: {m[:40]}"
+    # VAGUE: boilerplate
+    for m in VAGUE_MARKERS:
+        if re.search(m, text, re.IGNORECASE):
+            return "VAGUE", f"boilerplate: {m[:40]}"
+    return "OK", ""
+
+
+def main() -> None:
+    by_status: dict[str, list[tuple[Path, str]]] = {}
+    for p in OUTPUTS.rglob("*.md"):
+        text = p.read_text(encoding="utf-8", errors="replace")
+        status, note = _classify(p, text)
+        by_status.setdefault(status, []).append((p, note))
+
+    for status in ("OK", "EMPTY", "VAGUE", "NONPRODUCT"):
+        items = by_status.get(status, [])
+        print(f"\n=== {status}: {len(items)} ===")
+        for p, note in sorted(items):
+            print(f"  {p.relative_to(OUTPUTS)} | {note}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -100,6 +100,22 @@ def required_cells_set(spec: dict[str, Any]) -> set[Cell]:
     return out
 
 
+def not_implemented_cells_set(spec: dict[str, Any]) -> set[Cell]:
+    """Return the capability-boundary cells of *spec*.
+
+    Required cells annotated ``capability: not-implemented`` describe a
+    deliberate capability boundary (no code implements that product x format
+    combination for that domain), NOT a missing-evidence gap. They render as
+    ``不适用not-applicable`` instead of ``空gap`` — a real gap is "implemented
+    but no evidence".
+    """
+    out: set[Cell] = set()
+    for c in spec.get("required_cells", []):
+        if c.get("capability", "implemented") != "implemented":
+            out.add((c["domain"], c["product"], c["format"]))
+    return out
+
+
 def classify_cell(
     cell: dict[str, str] | Cell,
     produced: set[Cell],
@@ -109,13 +125,14 @@ def classify_cell(
     """Classify one domain x product x format cell.
 
     Priority (Oracle R8 — required empty LLM-gated cells are
-    ``未配置unconfigured``, NEVER ``空gap``):
+    ``未配置unconfigured``, NEVER ``空gap``; capability-boundary cells are
+    ``不适用not-applicable``, NEVER ``空gap``):
 
-    1. required AND produced                      -> 有produced
-    2. required AND NOT produced:
+    1. produced (required or not)                -> 有produced
+    2. required, capability: not-implemented     -> 不适用not-applicable
+    3. required AND NOT produced:
        - product in llm_gated_products AND LLM unavailable -> 未配置unconfigured
        - otherwise                              -> 空gap
-    3. non-required AND produced                 -> 有produced
     4. non-required AND no evidence              -> 不适用not-applicable
     """
     if isinstance(cell, dict):
@@ -124,6 +141,8 @@ def classify_cell(
         key = cell
     if key in produced:
         return PRODUCED
+    if key in not_implemented_cells_set(spec):
+        return NOT_APPLICABLE
     if key in required_cells_set(spec):
         if key[1] in spec.get("llm_gated_products", []) and not llm_available:
             return UNCONFIGURED

--- a/scripts/merge_demo_domains.py
+++ b/scripts/merge_demo_domains.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Merge demo-domain sources into .autoinfo/config.yaml for all 13 domains.
+
+Reads each src/autoinfo/data/domains/<d>/sources.yaml and appends the domain
+block (with its sources + topics) to the project config if the domain is not
+already configured. Preserves existing config blocks.
+
+Usage: HOME=/home/renanzai python3 scripts/merge_demo_domains.py [--dry-run]
+"""
+import sys
+import yaml
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CONFIG = ROOT / ".autoinfo" / "config.yaml"
+DOMAINS_DIR = ROOT / "src" / "autoinfo" / "data" / "domains"
+
+
+def main() -> None:
+    dry = "--dry-run" in sys.argv
+    cfg = yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
+    existing = {d.get("name") for d in cfg.get("domains", [])}
+    print(f"已配置域: {sorted(existing)}")
+
+    added = []
+    for ddir in sorted(DOMAINS_DIR.iterdir()):
+        if not ddir.is_dir():
+            continue
+        dname = ddir.name
+        sf = ddir / "sources.yaml"
+        if not sf.is_file():
+            continue
+        if dname in existing:
+            continue
+        demo = yaml.safe_load(sf.read_text(encoding="utf-8"))
+        if not isinstance(demo, dict) or not demo.get("sources"):
+            continue
+        block = {
+            "name": dname,
+            "active": True,
+            "sources": demo["sources"],
+        }
+        if demo.get("topics"):
+            block["topics"] = demo["topics"]
+        cfg["domains"].append(block)
+        added.append(dname)
+        print(f"  + {dname}: {len(demo['sources'])} sources")
+
+    print(f"\n新增域: {len(added)} -> 总域数: {len(cfg['domains'])}")
+    if added and not dry:
+        CONFIG.write_text(yaml.safe_dump(cfg, allow_unicode=True, sort_keys=False), encoding="utf-8")
+        print(f"written {CONFIG}")
+    else:
+        print("(dry-run — pass --write to apply)" if not added else "(dry-run)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/merge_demo_domains.py
+++ b/scripts/merge_demo_domains.py
@@ -8,8 +8,9 @@ already configured. Preserves existing config blocks.
 Usage: HOME=/home/renanzai python3 scripts/merge_demo_domains.py [--dry-run]
 """
 import sys
-import yaml
 from pathlib import Path
+
+import yaml
 
 ROOT = Path(__file__).resolve().parent.parent
 CONFIG = ROOT / ".autoinfo" / "config.yaml"
@@ -48,7 +49,9 @@ def main() -> None:
 
     print(f"\n新增域: {len(added)} -> 总域数: {len(cfg['domains'])}")
     if added and not dry:
-        CONFIG.write_text(yaml.safe_dump(cfg, allow_unicode=True, sort_keys=False), encoding="utf-8")
+        CONFIG.write_text(
+            yaml.safe_dump(cfg, allow_unicode=True, sort_keys=False), encoding="utf-8"
+        )
         print(f"written {CONFIG}")
     else:
         print("(dry-run — pass --write to apply)" if not added else "(dry-run)")

--- a/scripts/restore_matrix_spec.py
+++ b/scripts/restore_matrix_spec.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Restore the full 112-cell matrix spec with capability annotations.
+
+Restores the original 8-product x 7-format required_cells for both configured
+domains, and annotates each cell with its ACTUAL code capability (verified
+against src/autoinfo/output/__init__.py on 2026-08-09):
+
+  capability: implemented  -> code can produce this product/format
+  capability: not-implemented -> code lacks a render path / template for it
+
+The matrix tooling can then distinguish "real gap" (implemented but no
+evidence) from "capability boundary" (not implemented by design) instead of
+silently dropping the acceptance target.
+
+Usage: python3 scripts/restore_matrix_spec.py [--write]
+"""
+import sys
+from pathlib import Path
+
+SPEC = Path(__file__).resolve().parent.parent / "docs/dev/specs/end-user-matrix.yaml"
+
+# Verified capability matrix (source of truth: code inspection 2026-08-09)
+CAPABILITY = {
+    "digest": ["markdown", "html", "json", "agent", "audio", "epub", "audiobook"],
+    "report": ["markdown", "html", "json", "agent", "audio", "epub", "audiobook"],
+    "tutorial": ["markdown", "agent"],
+    "presentation": ["markdown", "html", "agent"],
+    "premium-briefing": ["markdown", "html"],
+    "column": ["markdown", "html"],
+    "magazine-digest": ["markdown", "html"],
+    "enterprise-briefing": ["markdown", "html"],
+}
+ALL_FORMATS = ["markdown", "html", "json", "agent", "audio", "epub", "audiobook"]
+DOMAINS = ["medical-research", "tech-ai-developer"]
+PRODUCTS = ["digest", "report", "tutorial", "presentation",
+            "premium-briefing", "column", "magazine-digest", "enterprise-briefing"]
+
+
+def main() -> None:
+    text = SPEC.read_text(encoding="utf-8")
+    start_marker = "# Required cells"
+    end_marker = "# Products whose generation requires an LLM key"
+    start = text.index(start_marker)
+    end = text.index(end_marker)
+
+    lines = [
+        "# Required cells — FULL end-user capability surface (8 products x 7 formats).",
+        "# Each cell carries a capability annotation so the matrix can distinguish",
+        "# 'real gap' (implemented but no evidence) from 'capability boundary'",
+        "# (not implemented by design — annotated, not silently dropped).",
+        "required_cells:",
+    ]
+    for d in DOMAINS:
+        for p in PRODUCTS:
+            for f in ALL_FORMATS:
+                cap = "implemented" if f in CAPABILITY[p] else "not-implemented"
+                lines.append(
+                    f"  - {{domain: {d}, product: {p}, format: {f}, capability: {cap}}}"
+                )
+    new_block = "\n".join(lines) + "\n"
+
+    old_text = text[start:end]
+    old_count = sum(1 for l in old_text.splitlines() if l.strip().startswith("- {domain:"))
+    print(f"old required_cells: {old_count} -> new: {len(DOMAINS)*len(PRODUCTS)*len(ALL_FORMATS)}")
+    print(f"implemented: {sum(1 for d in DOMAINS for p in PRODUCTS for f in ALL_FORMATS if f in CAPABILITY[p])}")
+    print(f"not-implemented: {sum(1 for d in DOMAINS for p in PRODUCTS for f in ALL_FORMATS if f not in CAPABILITY[p])}")
+
+    if "--write" in sys.argv:
+        SPEC.write_text(text[:start] + new_block + text[end:], encoding="utf-8")
+        print(f"written {SPEC}")
+    else:
+        print("(dry-run — pass --write to apply)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/restore_matrix_spec.py
+++ b/scripts/restore_matrix_spec.py
@@ -60,10 +60,21 @@ def main() -> None:
     new_block = "\n".join(lines) + "\n"
 
     old_text = text[start:end]
-    old_count = sum(1 for l in old_text.splitlines() if l.strip().startswith("- {domain:"))
-    print(f"old required_cells: {old_count} -> new: {len(DOMAINS)*len(PRODUCTS)*len(ALL_FORMATS)}")
-    print(f"implemented: {sum(1 for d in DOMAINS for p in PRODUCTS for f in ALL_FORMATS if f in CAPABILITY[p])}")
-    print(f"not-implemented: {sum(1 for d in DOMAINS for p in PRODUCTS for f in ALL_FORMATS if f not in CAPABILITY[p])}")
+    old_count = sum(
+        1 for line in old_text.splitlines() if line.strip().startswith("- {domain:")
+    )
+    implemented_count = sum(
+        1 for d in DOMAINS for p in PRODUCTS for f in ALL_FORMATS if f in CAPABILITY[p]
+    )
+    not_implemented_count = (
+        len(DOMAINS) * len(PRODUCTS) * len(ALL_FORMATS) - implemented_count
+    )
+    print(
+        f"old required_cells: {old_count} -> new: "
+        f"{len(DOMAINS)*len(PRODUCTS)*len(ALL_FORMATS)}"
+    )
+    print(f"implemented: {implemented_count}")
+    print(f"not-implemented: {not_implemented_count}")
 
     if "--write" in sys.argv:
         SPEC.write_text(text[:start] + new_block + text[end:], encoding="utf-8")

--- a/scripts/retry_product_quality.py
+++ b/scripts/retry_product_quality.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Retry-generate products until content quality passes (end-user view).
+
+Handles LLM flakiness: generates the product, audits its summary, retries up to
+N times. Skips products already OK.
+"""
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+os.environ.setdefault("AUTOINFO_LLM_API_KEY", os.environ.get("OPENCODE_GO_KEY", ""))
+
+from autoinfo.output import generate_report, generate_tutorial, PRODUCT_TEMPLATES
+
+OUT = ROOT / "outputs"
+
+VAGUE = [
+    "this report covers", "the article titled", "the provided content is empty",
+    "appears to discuss", "the instructions emphasize", "no content was provided",
+    "were submitted without substantive content", "all .* entries included in this report",
+]
+PLACEHOLDER = ["_No objectives defined._", "_No exercises provided._", "_No entries found"]
+
+
+def _quality(text: str) -> tuple[bool, str]:
+    for m in PLACEHOLDER:
+        if m.lower() in text.lower():
+            return False, f"placeholder {m[:30]}"
+    m = re.search(r"## (?:Executive Summary|The Big Idea)\s*\n(.*?)(?=\n## |\Z)", text, re.S)
+    summary = m.group(1) if m else text[:1200]
+    for v in VAGUE:
+        if re.search(v, summary, re.I):
+            return False, f"vague {v[:30]}"
+    return True, "ok"
+
+
+def _gen(domain: str, product: str) -> str:
+    if product == "tutorial":
+        return generate_tutorial(domain=domain, format="markdown")
+    tmpl = next(r["template"] for r in PRODUCT_TEMPLATES if r["name"] == product)
+    if product == "column":
+        return generate_report(domain=domain, period="weekly", format="markdown",
+                               report_type="column", product_template=tmpl)
+    return generate_report(domain=domain, period="weekly", format="markdown",
+                           product_template=tmpl)
+
+
+def main() -> None:
+    targets = [
+        ("medical-research", "enterprise-briefing"),
+        ("medical-research", "magazine-digest"),
+        ("medical-research", "tutorial"),
+        ("tech-ai-developer", "column"),
+    ]
+    for domain, product in targets:
+        ok = False
+        for attempt in range(1, 6):
+            try:
+                out = _gen(domain, product)
+                good, reason = _quality(str(out))
+                if good and len(str(out)) > 1500:
+                    d = OUT / domain
+                    d.mkdir(parents=True, exist_ok=True)
+                    p = d / f"{product}-markdown-{time.strftime('%Y%m%d-%H%M%S')}.md"
+                    p.write_text(str(out), encoding="utf-8")
+                    print(f"[OK ] {domain}/{product} attempt={attempt} {p.name} ({p.stat().st_size}b)")
+                    ok = True
+                    break
+                print(f"[retry] {domain}/{product} attempt={attempt}: {reason}")
+            except Exception as e:
+                print(f"[err ] {domain}/{product} attempt={attempt}: {type(e).__name__} {str(e)[:60]}")
+            time.sleep(1)
+        if not ok:
+            print(f"[FAIL] {domain}/{product} after 5 attempts")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/retry_product_quality.py
+++ b/scripts/retry_product_quality.py
@@ -14,7 +14,7 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "src"))
 os.environ.setdefault("AUTOINFO_LLM_API_KEY", os.environ.get("OPENCODE_GO_KEY", ""))
 
-from autoinfo.output import generate_report, generate_tutorial, PRODUCT_TEMPLATES
+from autoinfo.output import PRODUCT_TEMPLATES, generate_report, generate_tutorial  # noqa: E402
 
 OUT = ROOT / "outputs"
 
@@ -67,12 +67,18 @@ def main() -> None:
                     d.mkdir(parents=True, exist_ok=True)
                     p = d / f"{product}-markdown-{time.strftime('%Y%m%d-%H%M%S')}.md"
                     p.write_text(str(out), encoding="utf-8")
-                    print(f"[OK ] {domain}/{product} attempt={attempt} {p.name} ({p.stat().st_size}b)")
+                    print(
+                        f"[OK ] {domain}/{product} attempt={attempt} {p.name} "
+                        f"({p.stat().st_size}b)"
+                    )
                     ok = True
                     break
                 print(f"[retry] {domain}/{product} attempt={attempt}: {reason}")
             except Exception as e:
-                print(f"[err ] {domain}/{product} attempt={attempt}: {type(e).__name__} {str(e)[:60]}")
+                print(
+                    f"[err ] {domain}/{product} attempt={attempt}: "
+                    f"{type(e).__name__} {str(e)[:60]}"
+                )
             time.sleep(1)
         if not ok:
             print(f"[FAIL] {domain}/{product} after 5 attempts")

--- a/scripts/validation_delivery.py
+++ b/scripts/validation_delivery.py
@@ -176,17 +176,12 @@ _EMPTY_PLACEHOLDER_RE = re.compile(r"^\s*_no\s+.+_\.?\s*$", re.IGNORECASE)
 # requires all three); they get a non-empty marker so a complete product of
 # that format is not false-rejected (#172).
 #
-# Reports render via report.md.j2 (Executive Summary + per-theme Sections +
-# References) — they produce NO separate ``## Key Findings`` /
-# ``## Recommendations`` headings; the LLM writes findings + recommendations
-# inside the Executive Summary (see the report-generation prompt). The summary
-# is therefore the only canonical section a report genuinely emits, and it is
-# the sole required section. key_findings/recommendations stay optional: when a
-# report does carry those headings they are still detected and validated; when
-# absent the non-empty marker fills them so a complete report is not
-# false-rejected by D1.
+# Reports render via report.md.j2 (Executive Summary + Key Findings +
+# Recommendations + per-theme Sections + References) — the template now emits
+# separate ``## Key Findings`` / ``## Recommendations`` headings, so a report
+# must genuinely carry all three canonical sections.
 _PRODUCT_TYPE_REQUIRED_SECTIONS: dict[str, tuple[str, ...]] = {
-    "report": ("summary",),
+    "report": ("key_findings", "summary", "recommendations"),
     "presentation": ("key_findings",),          # at least one Slide N heading
     "digest": ("summary",),                     # Entries section / entries present
     "tutorial": ("key_findings", "recommendations"),  # Learning Objectives + Exercises

--- a/scripts/validation_delivery.py
+++ b/scripts/validation_delivery.py
@@ -182,10 +182,19 @@ _PRODUCT_TYPE_REQUIRED_SECTIONS: dict[str, tuple[str, ...]] = {
     "tutorial": ("key_findings", "recommendations"),  # Learning Objectives + Exercises
     "column": ("key_findings",),                # at least one content heading
     "magazine": ("key_findings",),              # at least one content heading
+    # Briefing products render via the report template family (Executive
+    # Summary + Sections + References); the only canonical section they
+    # genuinely produce is the summary (#172 follow-up).
+    "enterprise_briefing": ("summary",),
+    "premium_briefing": ("summary",),
+    "magazine_digest": ("summary",),
 }
 
 # Filename keywords -> product type (checked in order).
 _PRODUCT_TYPE_KEYWORDS: tuple[tuple[str, str], ...] = (
+    ("enterprise-briefing", "enterprise_briefing"),
+    ("premium-briefing", "premium_briefing"),
+    ("magazine-digest", "magazine_digest"),
     ("presentation", "presentation"),
     ("tutorial", "tutorial"),
     ("magazine", "magazine"),
@@ -316,8 +325,9 @@ def _is_empty_placeholder(content: str) -> bool:
 def _detect_product_type(file_path: Path, body: str = "") -> str:
     """Infer the product type from the artifact path (#172).
 
-    Filename keywords win (presentation/digest/tutorial/column/magazine);
-    everything else defaults to ``report``. Column products are persisted
+    Filename keywords win (presentation/digest/tutorial/column/magazine/
+    enterprise-briefing/premium-briefing/magazine-digest); everything else
+    defaults to ``report``. Column products are persisted
     under the ``report`` name (generate_report persists report_type="column"
     as report-markdown-*), so column-template headings in the body upgrade a
     report-named file to ``column``.

--- a/scripts/validation_delivery.py
+++ b/scripts/validation_delivery.py
@@ -175,8 +175,18 @@ _EMPTY_PLACEHOLDER_RE = re.compile(r"^\s*_no\s+.+_\.?\s*$", re.IGNORECASE)
 # outside a type's required set are still checked by the D1 gate (it always
 # requires all three); they get a non-empty marker so a complete product of
 # that format is not false-rejected (#172).
+#
+# Reports render via report.md.j2 (Executive Summary + per-theme Sections +
+# References) — they produce NO separate ``## Key Findings`` /
+# ``## Recommendations`` headings; the LLM writes findings + recommendations
+# inside the Executive Summary (see the report-generation prompt). The summary
+# is therefore the only canonical section a report genuinely emits, and it is
+# the sole required section. key_findings/recommendations stay optional: when a
+# report does carry those headings they are still detected and validated; when
+# absent the non-empty marker fills them so a complete report is not
+# false-rejected by D1.
 _PRODUCT_TYPE_REQUIRED_SECTIONS: dict[str, tuple[str, ...]] = {
-    "report": ("key_findings", "summary", "recommendations"),
+    "report": ("summary",),
     "presentation": ("key_findings",),          # at least one Slide N heading
     "digest": ("summary",),                     # Entries section / entries present
     "tutorial": ("key_findings", "recommendations"),  # Learning Objectives + Exercises

--- a/src/autoinfo/data/templates/report.md.j2
+++ b/src/autoinfo/data/templates/report.md.j2
@@ -12,6 +12,22 @@
 
 {{ executive_summary }}
 
+{% if key_findings %}
+## Key Findings
+
+{% for f in key_findings %}
+- {{ f }}
+{% endfor %}
+
+{% endif %}
+{% if recommendations %}
+## Recommendations
+
+{% for r in recommendations %}
+- {{ r }}
+{% endfor %}
+
+{% endif %}
 ---
 
 ## Sections

--- a/src/autoinfo/output/__init__.py
+++ b/src/autoinfo/output/__init__.py
@@ -4998,38 +4998,32 @@ def generate_tutorial(
         for e in entries
     )
 
-    prompt = (
-        f"You are a tutorial designer creating content for a {target_audience} "
-        f"audience ({audience_desc}). "
-        "Given the following knowledge base entries, structure them into a "
-        "coherent learning path. "
-        "Return a JSON object with the following fields:\n"
-        '  - "title": tutorial title (string)\n'
-        '  - "duration": estimated reading/completion time (string, e.g. "45 minutes")\n'
-        '  - "prerequisites": comma-separated prerequisites (string)\n'
-        '  - "objectives": array of 3-5 learning objective strings\n'
-        '  - "content": array of section objects, each with:\n'
-        '      - "heading": section heading\n'
-        '      - "body": 2-4 paragraph section content\n'
-        '      - "code_example": optional code/example snippet (string or null)\n'
-        '      - "code_language": language for the code snippet (string or null)\n'
-        '      - "key_takeaway": one-line takeaway (string or null)\n'
-        '  - "exercises": array of exercise objects, each with:\n'
-        '      - "title": exercise title\n'
-        '      - "description": exercise description\n'
-        '      - "hint": optional hint (string or null)\n'
-        '      - "solution": optional solution (string or null)\n'
-        '  - "summary": 2-3 sentence summary of the tutorial\n'
-        '  - "further_reading": array of reference strings\n\n'
-        f"KB Entries:\n{entry_summaries}\n\n"
-        "Return all fields in a single JSON object. Adapt depth, terminology, "
-        f"and examples specifically for a {target_audience} audience."
-    )
-
-    if custom_instructions:
-        prompt += f"\n\nAdditional instructions: {custom_instructions}"
+    if format == "agent":
+        prompt = _build_tutorial_json_prompt(
+            target_audience, audience_desc, entry_summaries, custom_instructions
+        )
+    else:
+        prompt = _build_tutorial_markdown_prompt(
+            target_audience, audience_desc, entry_summaries, custom_instructions
+        )
 
     llm_result = _call_llm_for_tutorial(prompt)
+
+    # -- Deterministic completeness (markdown path) --------------------------
+    # DeepSeek-V4-Flash does not reliably emit the tutorial schema as
+    # parseable JSON or markdown with a stable shape.  Ensure a domain that
+    # HAS entries never renders the all-empty template: replace an unusable
+    # LLM result entirely and fill any still-missing sections from KB entries.
+    if format == "markdown":
+        if not _tutorial_has_content(llm_result):
+            logger.warning(
+                "Tutorial LLM output unusable for domain '%s' (missing "
+                "objectives/content); falling back to KB-derived tutorial",
+                domain,
+            )
+        llm_result = _ensure_tutorial_complete(
+            llm_result, domain, entries, target_audience
+        )
 
     # -- Build template context -------------------------------------------
     generated_at = datetime.now(timezone.utc).isoformat()
@@ -5169,7 +5163,293 @@ def _call_llm_for_tutorial(prompt: str) -> dict[str, Any]:
         logger.error("Tutorial generation failed: %s", exc)
         return {}
     content: str = response.choices[0].message.content or ""
-    return _parse_json_response(content)
+    if not content:
+        return {}
+    parsed = _parse_json_response(content)
+    if parsed:
+        return parsed
+    return _parse_tutorial_markdown(content)
+
+
+def _build_tutorial_json_prompt(
+    target_audience: str,
+    audience_desc: str,
+    entry_summaries: str,
+    custom_instructions: str,
+) -> str:
+    """Build the structured-JSON tutorial prompt (agent-native format path)."""
+    prompt = (
+        f"You are a tutorial designer creating content for a {target_audience} "
+        f"audience ({audience_desc}). "
+        "Given the following knowledge base entries, structure them into a "
+        "coherent learning path. "
+        "Return a JSON object with the following fields:\n"
+        '  - "title": tutorial title (string)\n'
+        '  - "duration": estimated reading/completion time (string, e.g. "45 minutes")\n'
+        '  - "prerequisites": comma-separated prerequisites (string)\n'
+        '  - "objectives": array of 3-5 learning objective strings\n'
+        '  - "content": array of section objects, each with:\n'
+        '      - "heading": section heading\n'
+        '      - "body": 2-4 paragraph section content\n'
+        '      - "code_example": optional code/example snippet (string or null)\n'
+        '      - "code_language": language for the code snippet (string or null)\n'
+        '      - "key_takeaway": one-line takeaway (string or null)\n'
+        '  - "exercises": array of exercise objects, each with:\n'
+        '      - "title": exercise title\n'
+        '      - "description": exercise description\n'
+        '      - "hint": optional hint (string or null)\n'
+        '      - "solution": optional solution (string or null)\n'
+        '  - "summary": 2-3 sentence summary of the tutorial\n'
+        '  - "further_reading": array of reference strings\n\n'
+        f"KB Entries:\n{entry_summaries}\n\n"
+        "Return all fields in a single JSON object. Adapt depth, terminology, "
+        f"and examples specifically for a {target_audience} audience."
+    )
+    if custom_instructions:
+        prompt += f"\n\nAdditional instructions: {custom_instructions}"
+    return prompt
+
+
+def _build_tutorial_markdown_prompt(
+    target_audience: str,
+    audience_desc: str,
+    entry_summaries: str,
+    custom_instructions: str,
+) -> str:
+    """Build the flat-markdown tutorial prompt (robust markdown render path).
+
+    Plain markdown with fixed heading markers is far more reliably emitted by
+    the default model than the nested tutorial JSON schema, and the response is
+    parsed by heading instead of ``json.loads``.
+    """
+    prompt = (
+        f"You are a tutorial designer creating content for a {target_audience} "
+        f"audience ({audience_desc}). "
+        "Given the following knowledge base entries, structure them into a "
+        "coherent learning path. "
+        "Return plain Markdown with this exact structure:\n\n"
+        "# <tutorial title>\n"
+        "Duration: <estimated reading/completion time, e.g. '45 minutes'>\n"
+        "Prerequisites: <comma-separated prerequisites or 'None'>\n\n"
+        "## Learning Objectives\n"
+        "- <objective 1>\n"
+        "- <objective 2>\n"
+        "- <objective 3>\n\n"
+        "## Content\n"
+        "### <section heading 1>\n"
+        "<2-4 paragraphs of section content>\n"
+        "### <section heading 2>\n"
+        "<2-4 paragraphs of section content>\n\n"
+        "## Exercises\n"
+        "- <exercise 1>\n"
+        "- <exercise 2>\n\n"
+        "## Summary\n"
+        "<2-3 sentence summary>\n\n"
+        "## Further Reading\n"
+        "- <reference 1>\n"
+        "- <reference 2>\n\n"
+        "Use exactly the heading names above. Do NOT wrap your answer in a "
+        "code fence or emit JSON.\n\n"
+        f"KB Entries:\n{entry_summaries}\n\n"
+        "Adapt depth, terminology, and examples specifically for a "
+        f"{target_audience} audience."
+    )
+    if custom_instructions:
+        prompt += f"\n\nAdditional instructions: {custom_instructions}"
+    return prompt
+
+
+def _parse_tutorial_markdown(content: str) -> dict[str, Any]:
+    """Parse a markdown tutorial response into the tutorial context schema.
+
+    Handles the structure requested by ``_build_tutorial_markdown_prompt``:
+    ``# title``, optional ``Duration:`` / ``Prerequisites:`` lines,
+    ``## Learning Objectives`` bullets, ``## Content`` with ``### <heading>``
+    subsections, ``## Exercises`` bullets or ``### Exercise N:`` headings,
+    ``## Summary`` paragraph and ``## Further Reading`` bullets.  Returns
+    ``{}`` when *content* is empty.
+    """
+    if not content:
+        return {}
+    result: dict[str, Any] = {
+        "title": "",
+        "duration": "",
+        "prerequisites": "",
+        "objectives": [],
+        "content": [],
+        "exercises": [],
+        "summary": "",
+        "further_reading": [],
+    }
+    current_section = ""
+    content_heading = ""
+    content_body: list[str] = []
+    exercise_title = ""
+    exercise_body: list[str] = []
+
+    def flush_content() -> None:
+        nonlocal content_heading, content_body
+        if content_heading:
+            result["content"].append(
+                {
+                    "heading": content_heading,
+                    "body": "\n\n".join(line.strip() for line in content_body).strip(),
+                }
+            )
+            content_heading = ""
+            content_body = []
+
+    def flush_exercise() -> None:
+        nonlocal exercise_title, exercise_body
+        if exercise_title:
+            result["exercises"].append(
+                {
+                    "title": exercise_title,
+                    "description": "\n\n".join(
+                        line.strip() for line in exercise_body
+                    ).strip(),
+                }
+            )
+            exercise_title = ""
+            exercise_body = []
+
+    def is_bullet(text: str) -> bool:
+        return bool(
+            re.match(r"^(?:[-*]|\d+[.)])\s+\S", text)
+        )
+
+    def bullet_text(text: str) -> str:
+        return re.sub(r"^(?:[-*]|\d+[.)])\s+", "", text).strip()
+
+    for raw in content.splitlines():
+        line = raw.rstrip()
+        stripped = line.strip()
+        if line.startswith("# ") and not line.startswith("## "):
+            result["title"] = stripped.lstrip("#").strip()
+            continue
+        if not current_section and (
+            stripped.lower().startswith("duration:")
+            or stripped.lower().startswith("prerequisites:")
+        ):
+            key, _, value = stripped.partition(":")
+            result[key.strip().lower()] = value.strip()
+            continue
+        if stripped.startswith("## "):
+            flush_content()
+            flush_exercise()
+            current_section = stripped.lstrip("#").strip()
+            continue
+        if current_section in ("Learning Objectives", "Learning Goals"):
+            if is_bullet(stripped):
+                item = bullet_text(stripped)
+                if item:
+                    result["objectives"].append(item)
+            continue
+        if current_section == "Content":
+            if stripped.startswith("### "):
+                flush_content()
+                content_heading = stripped.lstrip("#").strip()
+                content_body = []
+            elif content_heading and stripped:
+                content_body.append(stripped)
+            continue
+        if current_section in ("Exercises", "Practice", "Practice Exercises"):
+            if stripped.startswith("### "):
+                flush_exercise()
+                heading = stripped.lstrip("#").strip()
+                exercise_title = re.sub(
+                    r"^Exercise\s*(\d+)?\s*[:.)-]?\s*",
+                    "",
+                    heading,
+                    flags=re.IGNORECASE,
+                ).strip() or heading
+                exercise_body = []
+            elif is_bullet(stripped):
+                flush_exercise()
+                item = bullet_text(stripped)
+                if item:
+                    result["exercises"].append({"title": item, "description": ""})
+            elif exercise_title and stripped:
+                exercise_body.append(stripped)
+            continue
+        if current_section in ("Summary", "Conclusion", "Wrap-Up"):
+            if stripped:
+                result["summary"] = (result["summary"] + " " + stripped).strip()
+            continue
+        if current_section in ("Further Reading", "References", "Resources"):
+            if is_bullet(stripped):
+                item = bullet_text(stripped)
+                if item:
+                    result["further_reading"].append(item)
+            elif stripped and not line.startswith(("---", "***")):
+                result["further_reading"].append(stripped)
+            continue
+    flush_content()
+    flush_exercise()
+    return result
+
+
+def _tutorial_has_content(result: dict[str, Any]) -> bool:
+    """True when a tutorial LLM result carries real objectives and content."""
+    return bool(result.get("objectives")) and bool(result.get("content"))
+
+
+def _entry_derived_sections(
+    entries: list[dict[str, Any]],
+) -> tuple[list[str], list[dict[str, str]], list[dict[str, str]], list[str]]:
+    """Derive objectives/content/exercises/further-reading from KB entries."""
+    objectives: list[str] = []
+    content: list[dict[str, str]] = []
+    exercises: list[dict[str, str]] = []
+    further_reading: list[str] = []
+    for index, entry in enumerate(entries):
+        title = entry.get("title") or f"Entry {index + 1}"
+        summary = entry.get("summary") or "(no summary available)"
+        if len(objectives) < 5:
+            objectives.append(title)
+        content.append({"heading": title, "body": summary})
+        exercises.append(
+            {
+                "title": f"What is the key finding in '{title}'?",
+                "description": (
+                    f"Summarize the main finding or conclusion of the entry "
+                    f"'{title}' in one or two sentences."
+                ),
+            }
+        )
+        url = entry.get("source_url")
+        if url and url not in further_reading:
+            further_reading.append(url)
+    return objectives[:5], content, exercises, further_reading[:20]
+
+
+def _ensure_tutorial_complete(
+    llm_result: dict[str, Any],
+    domain: str,
+    entries: list[dict[str, Any]],
+    target_audience: str,
+) -> dict[str, Any]:
+    """Guarantee the markdown tutorial never renders the all-empty template.
+
+    Keeps every usable field from *llm_result* (title, duration, objectives,
+    content, …) and fills any missing or empty section from the KB entries,
+    so a domain that HAS entries always produces a complete tutorial.
+    """
+    objectives, content, exercises, further_reading = _entry_derived_sections(entries)
+    return {
+        "title": llm_result.get("title") or f"{domain} — Tutorial",
+        "duration": llm_result.get("duration") or f"{len(entries)} minutes",
+        "prerequisites": llm_result.get("prerequisites") or "None",
+        "objectives": llm_result.get("objectives") or objectives,
+        "content": llm_result.get("content") or content,
+        "exercises": llm_result.get("exercises") or exercises,
+        "summary": llm_result.get("summary") or (
+            f"This tutorial walks through {len(entries)} knowledge base "
+            f"entries in the {domain} domain, covering the key findings "
+            f"for a {target_audience} audience."
+        ),
+        "further_reading": llm_result.get("further_reading") or further_reading,
+    }
 
 
 def _render_tutorial_template(context: dict[str, Any]) -> str:

--- a/src/autoinfo/output/__init__.py
+++ b/src/autoinfo/output/__init__.py
@@ -4126,14 +4126,14 @@ def _generate_executive_summary(
     # boilerplate / meta-narrative prose, so feed the highest-relevance
     # entries (capped to keep the prompt short) with their titles and summary
     # excerpts.
-    _MAX_DETAIL_ENTRIES = 40
-    _MAX_ENTRY_SUMMARY_CHARS = 120
+    max_detail_entries = 40
+    max_entry_summary_chars = 120
 
     ranked = sorted(
         (e for g in groupings for e in g["entries"]),
         key=lambda e: float(e.get("relevance_score") or 0.0),
         reverse=True,
-    )[:_MAX_DETAIL_ENTRIES]
+    )[:max_detail_entries]
     picked_ids = {id(e) for e in ranked}
 
     detail_lines: list[str] = []
@@ -4142,7 +4142,7 @@ def _generate_executive_summary(
         for e in picked:
             detail_lines.append(
                 f"- [{g['theme']}] {e.get('title', '')}: "
-                f"{(e.get('summary') or '')[: _MAX_ENTRY_SUMMARY_CHARS]}"
+                f"{(e.get('summary') or '')[: max_entry_summary_chars]}"
             )
         if len(picked) < len(g["entries"]):
             detail_lines.append(

--- a/src/autoinfo/output/__init__.py
+++ b/src/autoinfo/output/__init__.py
@@ -4121,10 +4121,35 @@ def _generate_executive_summary(
     Returns a dict ``{"executive_summary": str, "key_findings": list[str],
     "recommendations": list[str]}`` — never raises.
     """
-    themes_summary = "\n".join(
-        f"- {g['theme']}: {len(g['entries'])} entries"
-        for g in groupings
-    )
+    # Build a compact detail block of ACTUAL entry content so the LLM has
+    # concrete material to analyze. Theme-count summaries alone produce
+    # boilerplate / meta-narrative prose, so feed the highest-relevance
+    # entries (capped to keep the prompt short) with their titles and summary
+    # excerpts.
+    _MAX_DETAIL_ENTRIES = 40
+    _MAX_ENTRY_SUMMARY_CHARS = 120
+
+    ranked = sorted(
+        (e for g in groupings for e in g["entries"]),
+        key=lambda e: float(e.get("relevance_score") or 0.0),
+        reverse=True,
+    )[:_MAX_DETAIL_ENTRIES]
+    picked_ids = {id(e) for e in ranked}
+
+    detail_lines: list[str] = []
+    for g in groupings:
+        picked = [e for e in g["entries"] if id(e) in picked_ids]
+        for e in picked:
+            detail_lines.append(
+                f"- [{g['theme']}] {e.get('title', '')}: "
+                f"{(e.get('summary') or '')[: _MAX_ENTRY_SUMMARY_CHARS]}"
+            )
+        if len(picked) < len(g["entries"]):
+            detail_lines.append(
+                f"- [{g['theme']}] (+{len(g['entries']) - len(picked)} more "
+                "entries in this theme)"
+            )
+    entries_detail = "\n".join(detail_lines) or "(no entries)"
 
     cross_domain_prefix = ""
     if domains and len(domains) >= 2:
@@ -4136,10 +4161,12 @@ def _generate_executive_summary(
 
     prompt = (
         cross_domain_prefix +
-        "Write a report synthesis covering "
-        f"{len(entries)} knowledge base entries across "
-        f"the following themes:\n\n{themes_summary}\n\n"
-        "Focus on the key findings and overall significance. "
+        "Write a report synthesis analyzing the following knowledge base "
+        "entries (grouped by theme). Use the actual content: cite specific "
+        "findings, studies, and data points from the entries. Do NOT describe "
+        "the report structure or the writing instructions — write the analysis "
+        "itself.\n\n"
+        f"Themes and entries:\n{entries_detail}\n\n"
         "Return plain Markdown with this exact structure:\n\n"
         "## Executive Summary\n"
         "<2-3 paragraphs>\n\n"

--- a/src/autoinfo/output/__init__.py
+++ b/src/autoinfo/output/__init__.py
@@ -3021,6 +3021,8 @@ class ReportData:
     domain: str
     collection_id: str = ""
     executive_summary: str = ""
+    key_findings: list[str] = field(default_factory=list)
+    recommendations: list[str] = field(default_factory=list)
     sections: list[ReportSection] = field(default_factory=list)
     references: list[dict[str, Any]] = field(default_factory=list)
     appendices: list[dict[str, Any]] = field(default_factory=list)
@@ -3304,11 +3306,26 @@ def generate_report(
             )
 
     # -- Generate executive summary via LLM --------------------------------
-    executive_summary = _generate_executive_summary(
+    summary_result = _generate_executive_summary(
         extractor, entries, groupings, effective_instructions,
         target_audience=target_audience,
         domains=report_domains if is_cross_domain else None,
     )
+    # The synthesis returns a dict of ``{executive_summary, key_findings,
+    # recommendations}``.  Accept a bare string for backward compatibility
+    # (legacy callers / direct mocks) — treated as summary only.
+    if isinstance(summary_result, dict):
+        executive_summary = summary_result.get("executive_summary", "") or ""
+        key_findings = [
+            str(f) for f in (summary_result.get("key_findings") or [])
+        ]
+        recommendations = [
+            str(r) for r in (summary_result.get("recommendations") or [])
+        ]
+    else:
+        executive_summary = str(summary_result or "")
+        key_findings = []
+        recommendations = []
 
     # -- Build report data -------------------------------------------------
     sections = [
@@ -3338,6 +3355,8 @@ def generate_report(
         domain=report_title_domain,
         collection_id=collection_id or "",
         executive_summary=executive_summary,
+        key_findings=key_findings,
+        recommendations=recommendations,
         sections=sections,
         references=references,
     )
@@ -3346,8 +3365,8 @@ def generate_report(
     report_context: dict[str, Any] = {
         "llm_synthesis": {
             "executive_summary": report_data.executive_summary,
-            "key_findings": [s.title for s in report_data.sections],
-            "recommendations": [],
+            "key_findings": report_data.key_findings,
+            "recommendations": report_data.recommendations,
         },
     }
 
@@ -3427,12 +3446,9 @@ def generate_report(
             "generated_at": datetime.now(timezone.utc).isoformat(),
             "llm_synthesis": {
                 "executive_summary": report_data.executive_summary,
-                "key_findings": [
-                    {"topic": s.title, "detail": s.content}
-                    for s in report_data.sections
-                ],
+                "key_findings": report_data.key_findings,
                 "trends": [],
-                "recommendations": [],
+                "recommendations": report_data.recommendations,
             },
             "target_audience": target_audience,
         }
@@ -3572,7 +3588,7 @@ _DEFAULT_DOMAIN_GUIDANCE = (
 
 # Entries are grouped in batches of this size so the LLM prompt stays small
 # enough to return reliable JSON even for very long entry lists.
-_GROUPING_BATCH_SIZE = 20
+_GROUPING_BATCH_SIZE = 8
 
 
 def _group_by_theme(
@@ -3749,10 +3765,6 @@ def _llm_group_batch(
         )
     entry_summaries = "\n".join(entry_summaries_parts)
 
-    domain_guidance = _DOMAIN_THEME_GUIDANCE.get(
-        domain, _DEFAULT_DOMAIN_GUIDANCE
-    )
-
     cross_domain_instruction = ""
     if domains and len(domains) >= 2:
         cross_domain_instruction = (
@@ -3765,26 +3777,10 @@ def _llm_group_batch(
 
     prompt = (
         cross_domain_instruction +
-        "Group the following knowledge base entries into 3\u20135 coherent "
-        "themes. Each theme must represent a distinct topic area.\n\n"
-        "IMPORTANT: Do NOT group all entries under a single catch-all theme "
-        "like \"General\", \"Additional\", or \"Miscellaneous\". If you "
-        "cannot immediately distinguish themes, suggest reasonable "
-        "topic-based splits based on the entries\u2019 content. Each entry "
-        "should ideally go into its most specific thematic group.\n\n"
-        f"Domain context: {domain_guidance}. Consider themes relevant to "
-        "this domain when grouping.\n\n"
-        "Example of good grouping:\n"
-        "  Entries: [\"COVID vaccine efficacy in elderly\", "
-        "\"mRNA platform advances\", \"FDA fast-track approval process\"]\n"
-        "  Good themes: \"Vaccine Clinical Trials\", "
-        "\"mRNA Technology Advances\", \"Drug Regulation\"\n"
-        "  Bad (collapsed): \"General Medical Topics\"\n\n"
-        "Return a JSON object with a single key 'groups' whose value is "
-        "an array of objects. Each object must have:\n"
-        "  - 'theme': short theme name (2\u20135 words)\n"
-        "  - 'description': 2\u20133 sentence description of this theme\n"
-        "  - 'entry_ids': array of entry IDs belonging to this theme\n\n"
+        "Group the following knowledge base entries into 3\u20135 themes. "
+        "Each entry goes into exactly one theme. Do NOT use catch-all names "
+        "like \"General\" or \"Additional\".\n\n"
+        'Return JSON: {"groups": [{"theme": str, "entry_ids": [str]}]}\n\n'
         f"Entries:\n{entry_summaries}"
     )
 
@@ -3809,9 +3805,8 @@ def _llm_group_batch(
             "2\u20133 DISTINCT themes. Do NOT use catch-all themes like "
             "\"General\", \"Miscellaneous\", or \"Other\". Each entry must "
             "be assigned to the most specific theme that describes its "
-            "content. "
-            f"Domain context: {domain_guidance}. "
-            "Return a JSON object with a single key 'groups' as before.\n\n"
+            "content.\n\n"
+            'Return JSON: {"groups": [{"theme": str, "entry_ids": [str]}]}\n\n'
             f"Entries:\n{entry_summaries}"
         )
         try:
@@ -4113,10 +4108,18 @@ def _generate_executive_summary(
     custom_instructions: str = "",
     target_audience: str = "",
     domains: list[str] | None = None,
-) -> str:
-    """Generate an executive summary via LLM.
+) -> dict[str, Any]:
+    """Generate the report synthesis (summary + findings + recommendations).
 
-    Falls back to a simple bullet-list summary when the LLM call fails.
+    Asks the LLM for flat Markdown with ``## Executive Summary`` /
+    ``## Key Findings`` / ``## Recommendations`` headings — the default
+    model emits markdown far more reliably than a nested JSON schema —
+    and parses it by heading (see :func:`_parse_report_markdown`).
+
+    Falls back to a legacy single-string JSON summary via the extractor,
+    and finally to a bullet-list summary, so the report is never empty.
+    Returns a dict ``{"executive_summary": str, "key_findings": list[str],
+    "recommendations": list[str]}`` — never raises.
     """
     themes_summary = "\n".join(
         f"- {g['theme']}: {len(g['entries'])} entries"
@@ -4133,12 +4136,21 @@ def _generate_executive_summary(
 
     prompt = (
         cross_domain_prefix +
-        "Write a concise executive summary (3\u20135 paragraphs) for a "
-        f"report covering {len(entries)} knowledge base entries across "
+        "Write a report synthesis covering "
+        f"{len(entries)} knowledge base entries across "
         f"the following themes:\n\n{themes_summary}\n\n"
         "Focus on the key findings and overall significance. "
-        "Return a JSON object with a single key 'executive_summary' "
-        "whose value is the summary text."
+        "Return plain Markdown with this exact structure:\n\n"
+        "## Executive Summary\n"
+        "<2-3 paragraphs>\n\n"
+        "## Key Findings\n"
+        "- <finding 1>\n"
+        "- <finding 2>\n\n"
+        "## Recommendations\n"
+        "- <recommendation 1>\n"
+        "- <recommendation 2>\n\n"
+        "Use exactly the heading names above. Do NOT wrap your answer in a "
+        "code fence or emit JSON."
     )
     if custom_instructions:
         prompt += f"\n\nAdditional instructions: {custom_instructions}"
@@ -4148,10 +4160,20 @@ def _generate_executive_summary(
     if audience_prompt:
         prompt += f"\n\n{audience_prompt}"
 
+    # Primary path: flat markdown synthesis (reliable with the default model).
+    parsed = _parse_report_markdown(_call_llm_for_report_synthesis(prompt))
+    if parsed.get("executive_summary"):
+        return parsed
+
+    # Legacy path: single-string JSON summary via the extractor.
     try:
         raw = _llm_json_extract(extractor, prompt, "executive_summary")
         if raw and isinstance(raw, str) and raw.strip():
-            return raw.strip()
+            return {
+                "executive_summary": raw.strip(),
+                "key_findings": [],
+                "recommendations": [],
+            }
     except Exception as exc:
         logger.warning("Executive summary via LLM failed: %s", exc)
 
@@ -4160,10 +4182,114 @@ def _generate_executive_summary(
         f"- **{g['theme']}**: {len(g['entries'])} entry(ies)"
         for g in groupings
     )
-    return (
-        f"This report covers {len(entries)} knowledge base entries "
-        f"grouped into {len(groupings)} themes:\n\n{theme_bullets}"
-    )
+    return {
+        "executive_summary": (
+            f"This report covers {len(entries)} knowledge base entries "
+            f"grouped into {len(groupings)} themes:\n\n{theme_bullets}"
+        ),
+        "key_findings": [],
+        "recommendations": [],
+    }
+
+
+def _call_llm_for_report_synthesis(prompt: str) -> str:
+    """Call the configured LLM to synthesize report Markdown.
+
+    Uses the shared :func:`call_with_fallback` helper in plain-text mode
+    (no JSON mode) — the default model emits the flat ``## Executive
+    Summary`` / ``## Key Findings`` / ``## Recommendations`` structure
+    reliably while a nested JSON schema frequently comes back empty.
+    Returns the raw Markdown text (possibly empty) on success, ``""`` on
+    failure.
+    """
+    config_path = get_config_path()
+    if config_path and config_path.is_file():
+        try:
+            config = load_config(config_path)
+        except Exception:
+            config = Config()
+    else:
+        config = Config()
+
+    model = config.llm.resolve_model() or "openrouter/deepseek/deepseek-chat"
+    try:
+        response = call_with_fallback(
+            model=model,
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a report synthesis assistant. Given knowledge "
+                        "base entries and themes, write a concise executive "
+                        "summary, key findings, and recommendations. Respond "
+                        "with plain Markdown only — no JSON, no code fences."
+                    ),
+                },
+                {"role": "user", "content": prompt},
+            ],
+            json_mode=False,
+            max_tokens=4000,
+            temperature=0.1,
+            api_key=config.llm.api_key or None,
+            base_url=config.llm.base_url or None,
+        )
+    except Exception as exc:
+        logger.warning("Report synthesis via LLM failed: %s", exc)
+        return ""
+    content: str = response.choices[0].message.content or ""
+    return content.strip()
+
+
+def _parse_report_markdown(content: str) -> dict[str, Any]:
+    """Parse a Markdown report synthesis into the report context schema.
+
+    Handles the structure requested by the report-synthesis prompt:
+    ``## Executive Summary`` (paragraphs), ``## Key Findings`` (bullets)
+    and ``## Recommendations`` (bullets).  Returns ``{}`` when *content*
+    is empty or carries no executive summary.
+    """
+    if not content:
+        return {}
+    result: dict[str, Any] = {
+        "executive_summary": "",
+        "key_findings": [],
+        "recommendations": [],
+    }
+    current_section = ""
+    summary_lines: list[str] = []
+
+    def is_bullet(text: str) -> bool:
+        return bool(re.match(r"^(?:[-*]|\d+[.)])\s+\S", text))
+
+    def bullet_text(text: str) -> str:
+        return re.sub(r"^(?:[-*]|\d+[.)])\s+", "", text).strip()
+
+    for raw in content.splitlines():
+        line = raw.rstrip()
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            current_section = stripped.lstrip("#").strip().lower()
+            continue
+        if not current_section:
+            continue
+        if current_section in ("executive summary", "summary", "overview"):
+            if stripped and not line.startswith(("---", "***")):
+                summary_lines.append(stripped)
+        elif current_section in ("key findings", "findings", "main findings"):
+            if is_bullet(stripped):
+                item = bullet_text(stripped)
+                if item:
+                    result["key_findings"].append(item)
+        elif current_section in ("recommendations", "next steps", "action items"):
+            if is_bullet(stripped):
+                item = bullet_text(stripped)
+                if item:
+                    result["recommendations"].append(item)
+
+    result["executive_summary"] = "\n\n".join(summary_lines).strip()
+    if not result["executive_summary"]:
+        return {}
+    return result
 
 
 def _llm_json_extract(
@@ -4206,6 +4332,8 @@ def _report_data_to_dict(
         "domain": report_data.domain,
         "collection_id": report_data.collection_id,
         "executive_summary": report_data.executive_summary,
+        "key_findings": report_data.key_findings,
+        "recommendations": report_data.recommendations,
         "source_tier_badge": source_tier_badge,
         "sections": [
             {
@@ -4268,6 +4396,8 @@ def _render_report_json(report_data: ReportData, period: str = "weekly") -> str:
     output = {
         "title": report_data.title,
         "summary": report_data.executive_summary,
+        "key_findings": report_data.key_findings,
+        "recommendations": report_data.recommendations,
         "entries": entries_list,
         "metadata": {
             "generated_at": report_data.generated_at,
@@ -4328,6 +4458,8 @@ def _render_report_template(report_data: ReportData, source_tier_badge: bool = T
         domain=report_data.domain,
         collection_id=report_data.collection_id,
         executive_summary=report_data.executive_summary,
+        key_findings=report_data.key_findings,
+        recommendations=report_data.recommendations,
         source_tier_badge=source_tier_badge,
         sections=[
             {

--- a/src/autoinfo/output/__init__.py
+++ b/src/autoinfo/output/__init__.py
@@ -3570,6 +3570,10 @@ _DEFAULT_DOMAIN_GUIDANCE = (
     "policy & regulation, emerging innovations"
 )
 
+# Entries are grouped in batches of this size so the LLM prompt stays small
+# enough to return reliable JSON even for very long entry lists.
+_GROUPING_BATCH_SIZE = 20
+
 
 def _group_by_theme(
     extractor: LLMExtractor,
@@ -3608,10 +3612,134 @@ def _group_by_theme(
                 },
             ]
 
-    Falls back to a single ``"General"`` group when the LLM call fails
-    or when the LLM repeatedly collapses entries into one theme.
+    Entries are grouped in batches of at most ``_GROUPING_BATCH_SIZE`` so the
+    LLM prompt stays small enough to return reliable JSON even for long entry
+    lists; resulting themes are then merged across batches by normalized
+    name.  When the LLM fails or collapses a batch, a deterministic keyword /
+    source-type / domain heuristic is used instead, so the entries never
+    collapse into a single ``"General"`` group while more than one distinct
+    topic is detectable.
     """
-    # Build a compact representation of entries for the LLM prompt
+    if not entries:
+        return []
+
+    batch_size = _GROUPING_BATCH_SIZE
+    batches = [
+        entries[i : i + batch_size] for i in range(0, len(entries), batch_size)
+    ]
+
+    merged: list[dict[str, Any]] = []
+    for batch in batches:
+        merged.extend(
+            _group_batch_by_theme(extractor, batch, domain=domain, domains=domains)
+        )
+
+    return _ensure_all_entries_grouped(_merge_theme_groups(merged), entries)
+
+
+def _group_batch_by_theme(
+    extractor: LLMExtractor,
+    entries: list[dict[str, Any]],
+    domain: str = "",
+    domains: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Group a single batch of entries (at most ``_GROUPING_BATCH_SIZE``).
+
+    Uses the LLM (with an anti-collapse retry) and maps the returned entry
+    IDs back to entry objects.  Falls back to a deterministic keyword /
+    source-type / domain grouping when the LLM fails or collapses the batch.
+    """
+    groups_raw = _llm_group_batch(extractor, entries, domain=domain, domains=domains)
+    if not groups_raw:
+        groups = _deterministic_grouping(entries, domain=domain)
+        if groups is not None:
+            return groups
+        return [
+            {
+                "theme": "General",
+                "description": (
+                    f"All {len(entries)} entries included in this report."
+                ),
+                "entries": list(entries),
+            }
+        ]
+
+    entry_map: dict[str, dict[str, Any]] = {
+        e.get("entry_id", ""): e for e in entries if e.get("entry_id")
+    }
+
+    result: list[dict[str, Any]] = []
+    for g in groups_raw:
+        group_entries = [
+            entry_map[eid]
+            for eid in g.get("entry_ids", [])
+            if eid in entry_map
+        ]
+        if group_entries:
+            result.append({
+                "theme": g.get("theme", "Untitled"),
+                "description": g.get("description", ""),
+                "entries": group_entries,
+            })
+
+    # -- Coverage guard -----------------------------------------------------
+    # The LLM sometimes returns parseable JSON whose entry_ids do not match
+    # the actual entry IDs, which would dump every entry into a single
+    # catch-all.  If the LLM groups cover fewer than half the batch, treat
+    # the result as unreliable and fall back to deterministic grouping.
+    matched_count = sum(len(g["entries"]) for g in result)
+    if matched_count < max(1, len(entries) // 2):
+        logger.warning(
+            "LLM groups matched only %d/%d entries, falling back to "
+            "deterministic grouping",
+            matched_count,
+            len(entries),
+        )
+        groups = _deterministic_grouping(entries, domain=domain)
+        if groups is not None:
+            return groups
+        return [
+            {
+                "theme": "General",
+                "description": (
+                    f"All {len(entries)} entries included in this report."
+                ),
+                "entries": list(entries),
+            }
+        ]
+
+    # Ensure no entry is left out (ungrouped entries go into a catch-all)
+    grouped_ids: set[str] = {
+        e.get("entry_id", "")
+        for g in result
+        for e in g["entries"]
+        if e.get("entry_id")
+    }
+    ungrouped = [e for e in entries if e.get("entry_id", "") not in grouped_ids]
+    if ungrouped:
+        result.append({
+            "theme": "Additional Topics",
+            "description": (
+                f"{len(ungrouped)} entry(ies) not covered by other themes."
+            ),
+            "entries": ungrouped,
+        })
+
+    return result
+
+
+def _llm_group_batch(
+    extractor: LLMExtractor,
+    entries: list[dict[str, Any]],
+    domain: str = "",
+    domains: list[str] | None = None,
+) -> list[dict[str, Any]] | None:
+    """Ask the LLM to group a single batch of entries into themes.
+
+    Returns the raw parsed ``groups`` list (each object carries ``theme``,
+    ``description`` and ``entry_ids``) or ``None`` when the LLM fails or
+    repeatedly collapses the batch into a single theme.
+    """
     entry_summaries_parts: list[str] = []
     for e in entries:
         entry_domain = e.get("domain", domain)
@@ -3695,102 +3823,266 @@ def _group_by_theme(
         # If retry STILL produced only 1 group, treat as failure → fallback
         if groups_raw and len(groups_raw) <= 1:
             logger.warning(
-                "Strict retry returned only %d group(s), falling back to General",
+                "Strict retry returned only %d group(s), falling back to "
+                "deterministic grouping",
                 len(groups_raw),
             )
             groups_raw = None
 
-    if not groups_raw:
-        # Smart fallback: split by domain rather than lumping everything under "General".
-        # This handles the case where the LLM fails or collapses all entries.
-        from collections import defaultdict
-        domain_groups: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
-        for e in entries:
-            d = (e.get("domain") or "").strip() or "Unknown"
-            domain_groups[d].append(e)
+    result: list[dict[str, Any]] | None = groups_raw
+    return result
 
-        if len(domain_groups) >= 2:
-            groups = []
-            for domain_name in sorted(domain_groups):
-                theme_name = domain_name.replace("-", " ").title() if domain_name != "Unknown" else "Other Sources"  # noqa: E501
-                groups.append({
-                    "theme": theme_name,
-                    "description": (
-                        f"{len(domain_groups[domain_name])} entries from "
-                        f"{domain_name or 'other sources'}."
-                    ),
-                    "entries": domain_groups[domain_name],
-                })
-            return groups
+def _deterministic_grouping(
+    entries: list[dict[str, Any]],
+    domain: str = "",
+) -> list[dict[str, Any]] | None:
+    """Group entries deterministically without the LLM.
 
-        # Single domain (or all unknown): split by source_type instead
-        source_groups: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
-        for e in entries:
-            st = (e.get("source_type") or "").strip() or "unknown"
-            source_groups[st].append(e)
+    Splits by ``source_type`` (existing fallback), then by ``domain``, and
+    finally by a keyword classifier built from the domain's ``_keywords.yaml``
+    when the simpler splits still collapse to a single group.  Returns
+    ``None`` only when fewer than two distinct topics are detectable, so the
+    caller can decide on a last-resort group.
+    """
+    from collections import defaultdict
 
-        if len(source_groups) >= 2:
-            groups = []
-            for st in sorted(source_groups):
-                theme_name = st.upper()
-                groups.append({
-                    "theme": theme_name,
-                    "description": f"{len(source_groups[st])} entries from {st} sources.",
-                    "entries": source_groups[st],
-                })
-            return groups
+    # 1. Split by source_type
+    source_groups: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+    for e in entries:
+        st = (e.get("source_type") or "").strip() or "unknown"
+        source_groups[st].append(e)
 
-        # Last resort — single group with all entries
+    if len(source_groups) >= 2:
+        return [
+            {
+                "theme": st.upper(),
+                "description": f"{len(es)} entries from {st} sources.",
+                "entries": es,
+            }
+            for st, es in sorted(source_groups.items())
+        ]
+
+    # 2. Split by domain
+    domain_groups: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+    for e in entries:
+        d = (e.get("domain") or "").strip() or "Unknown"
+        domain_groups[d].append(e)
+
+    if len(domain_groups) >= 2:
+        return [
+            {
+                "theme": (
+                    d.replace("-", " ").title() if d != "Unknown" else "Other Sources"
+                ),
+                "description": f"{len(es)} entries from {d or 'other sources'}.",
+                "entries": es,
+            }
+            for d, es in sorted(domain_groups.items())
+        ]
+
+    # 3. Keyword classifier (from knowledge/<domain>/_keywords.yaml) — this
+    #    replaces the old "General" dump when the entries are all from one
+    #    source_type and one domain but still cover distinct topics.
+    keyword_groups = _keyword_group_entries(entries, domain=domain)
+    if keyword_groups is not None:
+        return keyword_groups
+
+    # Only a single distinct topic is detectable.
+    return None
+
+
+def _keyword_group_entries(
+    entries: list[dict[str, Any]],
+    domain: str = "",
+) -> list[dict[str, Any]] | None:
+    """Group entries by keyword topics from the domain's ``_keywords.yaml``.
+
+    Loads topic keywords from ``knowledge/<domain>/_keywords.yaml`` (when
+    present) and maps each entry's title/summary to the longest keyword it
+    contains.  Returns a list of groups, or ``None`` when fewer than two
+    distinct keyword topics are detectable so the caller can fall back to
+    source-type / domain grouping.
+    """
+    from collections import defaultdict
+
+    topics = _load_keyword_topics(domain)
+    if not topics:
+        return None
+
+    # Normalize once, keep the original spelling for display, and match the
+    # most specific (longest) keyword first.
+    norm_topics: list[tuple[str, str]] = []
+    for t in topics:
+        nt = _normalize_text(t)
+        if len(nt) >= 3:
+            norm_topics.append((nt, t))
+    if not norm_topics:
+        return None
+    norm_topics.sort(key=lambda pair: len(pair[0]), reverse=True)
+
+    groups: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+    for e in entries:
+        text = _normalize_text(
+            f"{e.get('title', '')} {e.get('summary', '')}"
+        )
+        best = _match_keyword(text, norm_topics)
+        groups[best if best else "__unmatched__"].append(e)
+
+    keyword_names = [name for name in groups if name != "__unmatched__"]
+    if not keyword_names:
+        return None
+    if len(keyword_names) == 1 and not groups.get("__unmatched__"):
+        return None
+
+    result: list[dict[str, Any]] = []
+    for name, es in groups.items():
+        if name == "__unmatched__":
+            continue
+        result.append({
+            "theme": name.title(),
+            "description": f"{len(es)} entries related to '{name}'.",
+            "entries": es,
+        })
+
+    unmatched = groups.get("__unmatched__", [])
+    if unmatched:
+        result.append({
+            "theme": "Additional Topics",
+            "description": (
+                f"{len(unmatched)} entry(ies) not matched to a topic keyword."
+            ),
+            "entries": unmatched,
+        })
+    return result
+
+
+def _load_keyword_topics(domain: str) -> list[str]:
+    """Load non-deprecated topic keywords for *domain* from ``_keywords.yaml``."""
+    if not domain:
+        return []
+    path = Path("knowledge") / domain / "_keywords.yaml"
+    if not path.is_file():
+        return []
+    try:
+        raw: dict[str, Any] = yaml.safe_load(
+            path.read_text(encoding="utf-8")
+        ) or {}
+    except Exception as exc:
+        logger.warning("Failed to read keyword file %s: %s", path, exc)
+        return []
+    kw_map: dict[str, Any] = raw.get("keywords", {}) or {}
+    topics: list[str] = []
+    for keyword, data in kw_map.items():
+        if isinstance(data, dict) and data.get("state") == "deprecated":
+            continue
+        topics.append(keyword)
+    return topics
+
+
+def _match_keyword(
+    text: str,
+    norm_topics: list[tuple[str, str]],
+) -> str:
+    """Return the longest normalized topic keyword found in *text*.
+
+    Matches on normalized (lower-cased, punctuation-stripped) text with word
+    boundaries so short keywords do not match inside unrelated words.
+    """
+    for nt, _original in norm_topics:
+        if re.search(r"(?:^|\s)" + re.escape(nt) + r"(?=\s|$)", text):
+            return nt
+    return ""
+
+
+def _normalize_text(value: str) -> str:
+    """Lower-case *value*, strip punctuation and collapse whitespace."""
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", value.lower())).strip()
+
+
+def _normalize_theme_text(value: str) -> str:
+    """Normalize a theme name for exact-name merging across batches."""
+    return _normalize_text(str(value))
+
+
+def _merge_theme_groups(
+    groups: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Merge groups that share the same normalized theme name.
+
+    Entries are deduplicated by ``entry_id`` when merging so the same entry
+    is never reported under a theme twice.
+    """
+    from collections import defaultdict
+
+    by_name: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+    for g in groups:
+        theme = (g.get("theme") or "").strip() or "Untitled"
+        key = _normalize_theme_text(theme) or theme.strip().lower()
+        by_name[key].append(g)
+
+    result: list[dict[str, Any]] = []
+    for merged in by_name.values():
+        theme = merged[0]["theme"]
+        description = next(
+            (g["description"] for g in merged if g.get("description")), ""
+        )
+        seen: set[str] = set()
+        entries: list[dict[str, Any]] = []
+        for g in merged:
+            for e in g["entries"]:
+                eid = e.get("entry_id", "")
+                if eid and eid in seen:
+                    continue
+                if eid:
+                    seen.add(eid)
+                entries.append(e)
+        result.append({
+            "theme": theme,
+            "description": description,
+            "entries": entries,
+        })
+    return result
+
+
+def _ensure_all_entries_grouped(
+    groups: list[dict[str, Any]],
+    entries: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Guarantee every input entry appears in some group."""
+    if not groups:
         return [
             {
                 "theme": "General",
                 "description": (
                     f"All {len(entries)} entries included in this report."
                 ),
-                "entries": entries,
+                "entries": list(entries),
             }
         ]
 
-    # Map entry IDs back to actual entry objects
-    entry_map: dict[str, dict[str, Any]] = {}
-    for e in entries:
-        eid = e.get("entry_id", "")
-        if eid:
-            entry_map[eid] = e
-
-    result: list[dict[str, Any]] = []
-    for g in groups_raw:
-        group_entries = [
-            entry_map[eid]
-            for eid in g.get("entry_ids", [])
-            if eid in entry_map
-        ]
-        if group_entries:
-            result.append({
-                "theme": g.get("theme", "Untitled"),
-                "description": g.get("description", ""),
-                "entries": group_entries,
+    grouped_ids: set[str] = {
+        e.get("entry_id", "")
+        for g in groups
+        for e in g["entries"]
+        if e.get("entry_id")
+    }
+    missing = [
+        e
+        for e in entries
+        if not (e.get("entry_id", "") and e["entry_id"] in grouped_ids)
+    ]
+    if missing:
+        if len(groups) >= 2:
+            groups.append({
+                "theme": "Additional Topics",
+                "description": (
+                    f"{len(missing)} entry(ies) not covered by other themes."
+                ),
+                "entries": missing,
             })
-
-    # Ensure no entry is left out (ungrouped entries go into a catch-all)
-    grouped_ids: set[str] = set()
-    for g in result:
-        for e in g["entries"]:
-            eid = e.get("entry_id", "")
-            if eid:
-                grouped_ids.add(eid)
-
-    ungrouped = [e for e in entries if e.get("entry_id", "") not in grouped_ids]
-    if ungrouped:
-        result.append({
-            "theme": "Additional Topics",
-            "description": (
-                f"{len(ungrouped)} entry(ies) not covered by other themes."
-            ),
-            "entries": ungrouped,
-        })
-
-    return result
+        else:
+            groups[0]["entries"].extend(missing)
+    return groups
 
 
 def _normalize_report_audience(target_audience: str) -> str:

--- a/tests/kb/test_promotion_triggers.py
+++ b/tests/kb/test_promotion_triggers.py
@@ -306,6 +306,10 @@ class TestReportPromotionTrigger:
         with (
             patch("autoinfo.output.KBStore", return_value=store),
             patch.object(_get_llm_extractor_class(), "extract", mock_extract),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
+            ),
         ):
             result = generate_report(domain="medical-research", format="markdown")
 

--- a/tests/output/test_cross_domain_report.py
+++ b/tests/output/test_cross_domain_report.py
@@ -19,7 +19,6 @@ import pytest
 
 from autoinfo.models import ExtractionResult
 
-
 # Fixtures
 # ---------------------------------------------------------------------------
 

--- a/tests/output/test_cross_domain_report.py
+++ b/tests/output/test_cross_domain_report.py
@@ -165,6 +165,10 @@ class TestCrossDomainReport:
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
             ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
+            ),
         ):
             mock_store = MagicMock()
             mock_store.list_entries.return_value = medical_entries
@@ -194,6 +198,10 @@ class TestCrossDomainReport:
             patch("autoinfo.output.KBStore") as mock_kb_cls,
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
+            ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
             ),
         ):
             mock_store = MagicMock()
@@ -240,6 +248,10 @@ class TestCrossDomainReport:
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
             ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
+            ),
         ):
             mock_store = MagicMock()
 
@@ -281,6 +293,10 @@ class TestCrossDomainReport:
             patch("autoinfo.output.KBStore") as mock_kb_cls,
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
+            ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
             ),
         ):
             mock_store = MagicMock()
@@ -346,6 +362,10 @@ class TestCrossDomainReport:
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
             ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
+            ),
         ):
             mock_store = MagicMock()
             mock_store.list_entries.return_value = medical_entries
@@ -375,6 +395,10 @@ class TestCrossDomainReport:
             patch("autoinfo.output.KBStore") as mock_kb_cls,
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
+            ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
             ),
         ):
             mock_store = MagicMock()

--- a/tests/test_column_product.py
+++ b/tests/test_column_product.py
@@ -186,6 +186,10 @@ class TestColumnFreePath:
         with (
             patch("autoinfo.output.KBStore") as mock_kb_cls,
             patch.object(_get_llm_extractor_class(), "extract", mock_extract),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
+            ),
         ):
             mock_store = MagicMock()
             mock_store.list_entries.return_value = sample_entries

--- a/tests/test_column_product.py
+++ b/tests/test_column_product.py
@@ -20,8 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from autoinfo.models import ExtractionResult
-from autoinfo.output import PRODUCT_TEMPLATES, _VALID_REPORT_TYPES
-
+from autoinfo.output import _VALID_REPORT_TYPES, PRODUCT_TEMPLATES
 
 # ===================================================================
 # Fixtures
@@ -76,7 +75,10 @@ def _make_grouping_result() -> ExtractionResult:
             "groups": [
                 {
                     "theme": "IVF & Reproductive Medicine",
-                    "description": "Advancements in IVF treatment and assisted reproductive technologies.",
+                    "description": (
+                        "Advancements in IVF treatment and assisted "
+                        "reproductive technologies."
+                    ),
                     "entry_ids": ["entry-001"],
                 },
                 {

--- a/tests/test_coverage_matrix.py
+++ b/tests/test_coverage_matrix.py
@@ -99,6 +99,51 @@ def test_classify_cell_accepts_tuple_form(spec):
     ) == cm.NOT_APPLICABLE
 
 
+def test_capability_boundary_required_cell_is_not_applicable(spec):
+    """A required cell annotated capability: not-implemented is a deliberate
+    capability boundary — it must render 不适用not-applicable, NEVER 空gap or
+    未配置unconfigured, whether or not the LLM is available."""
+    # (medical-research, tutorial, html) is required + not-implemented in the spec
+    cell = {"domain": "medical-research", "product": "tutorial", "format": "html"}
+    assert ("medical-research", "tutorial", "html") in cm.not_implemented_cells_set(spec)
+    assert cm.classify_cell(cell, EMPTY_PRODUCED, llm_available=True, spec=spec) == cm.NOT_APPLICABLE
+    assert cm.classify_cell(cell, EMPTY_PRODUCED, llm_available=False, spec=spec) == cm.NOT_APPLICABLE
+    assert cm.classify_cell(cell, EMPTY_PRODUCED, llm_available=True, spec=spec) != cm.GAP
+    assert cm.classify_cell(cell, EMPTY_PRODUCED, llm_available=False, spec=spec) != cm.UNCONFIGURED
+
+
+def test_capability_boundary_with_evidence_is_produced(spec):
+    """Evidence trumps the capability annotation: a not-implemented cell that
+    somehow has produced artifacts still renders 有produced."""
+    cell = {"domain": "medical-research", "product": "tutorial", "format": "html"}
+    produced = {("medical-research", "tutorial", "html")}
+    assert cm.classify_cell(cell, produced, llm_available=True, spec=spec) == cm.PRODUCED
+
+
+def test_implemented_required_cell_without_evidence_is_still_gap(spec):
+    """capability: implemented required cells stay real gaps when empty —
+    the annotation must NOT blanket-exempt required cells from gap status."""
+    cell = {"domain": "medical-research", "product": "tutorial", "format": "markdown"}
+    assert ("medical-research", "tutorial", "markdown") not in cm.not_implemented_cells_set(spec)
+    assert cm.classify_cell(cell, EMPTY_PRODUCED, llm_available=True, spec=spec) == cm.GAP
+
+
+def test_required_cells_set_contains_all_required_cells(spec):
+    """required_cells_set (gap-domain) is a superset of the implemented cells
+    while not_implemented_cells_set holds only the capability boundaries."""
+    required = cm.required_cells_set(spec)
+    not_impl = cm.not_implemented_cells_set(spec)
+    assert required
+    assert not_impl
+    assert not_impl <= required
+    for c in spec["required_cells"]:
+        triple = (c["domain"], c["product"], c["format"])
+        if c["capability"] == "implemented":
+            assert triple in required and triple not in not_impl
+        else:
+            assert triple in not_impl
+
+
 # ---------------------------------------------------------------------------
 # Spec file validity
 # ---------------------------------------------------------------------------
@@ -123,7 +168,8 @@ def test_spec_has_at_least_10_required_cells(spec):
     required = spec["required_cells"]
     assert len(required) >= 10
     for cell in required:
-        assert set(cell) == {"domain", "product", "format"}
+        assert set(cell) == {"domain", "product", "format", "capability"}
+        assert cell["capability"] in {"implemented", "not-implemented"}
         assert cell["domain"] in spec["domains"]
         assert cell["product"] in spec["products"]
         assert cell["format"] in spec["formats"]

--- a/tests/test_coverage_matrix.py
+++ b/tests/test_coverage_matrix.py
@@ -103,13 +103,18 @@ def test_capability_boundary_required_cell_is_not_applicable(spec):
     """A required cell annotated capability: not-implemented is a deliberate
     capability boundary — it must render 不适用not-applicable, NEVER 空gap or
     未配置unconfigured, whether or not the LLM is available."""
-    # (medical-research, tutorial, html) is required + not-implemented in the spec
     cell = {"domain": "medical-research", "product": "tutorial", "format": "html"}
     assert ("medical-research", "tutorial", "html") in cm.not_implemented_cells_set(spec)
-    assert cm.classify_cell(cell, EMPTY_PRODUCED, llm_available=True, spec=spec) == cm.NOT_APPLICABLE
-    assert cm.classify_cell(cell, EMPTY_PRODUCED, llm_available=False, spec=spec) == cm.NOT_APPLICABLE
+    assert cm.classify_cell(
+        cell, EMPTY_PRODUCED, llm_available=True, spec=spec
+    ) == cm.NOT_APPLICABLE
+    assert cm.classify_cell(
+        cell, EMPTY_PRODUCED, llm_available=False, spec=spec
+    ) == cm.NOT_APPLICABLE
     assert cm.classify_cell(cell, EMPTY_PRODUCED, llm_available=True, spec=spec) != cm.GAP
-    assert cm.classify_cell(cell, EMPTY_PRODUCED, llm_available=False, spec=spec) != cm.UNCONFIGURED
+    assert cm.classify_cell(
+        cell, EMPTY_PRODUCED, llm_available=False, spec=spec
+    ) != cm.UNCONFIGURED
 
 
 def test_capability_boundary_with_evidence_is_produced(spec):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -15,14 +15,12 @@ Covers:
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from autoinfo.models import ExtractionResult
-
 
 # ===================================================================
 # Fixtures
@@ -81,7 +79,10 @@ def _make_grouping_result() -> ExtractionResult:
             "groups": [
                 {
                     "theme": "IVF & Reproductive Medicine",
-                    "description": "Advancements in IVF treatment and assisted reproductive technologies.",
+                    "description": (
+                        "Advancements in IVF treatment and assisted "
+                        "reproductive technologies."
+                    ),
                     "entry_ids": ["entry-001"],
                 },
                 {
@@ -655,8 +656,13 @@ class TestReportTypes:
         assert "Industry Overview" in instructions
         assert "Key Developments" in instructions
 
-    def test_standard_type_passes_empty_instructions(self, sample_entries: list[dict]) -> None:
-        """``report_type="standard"`` passes empty/unchanged custom_instructions to executive summary."""
+    def test_standard_type_passes_empty_instructions(
+        self, sample_entries: list[dict]
+    ) -> None:
+        (
+            """``report_type="standard"`` passes empty/unchanged custom_instructions"""
+            """ to executive summary."""
+        )
         with (
             patch("autoinfo.output.KBStore") as mock_kb_cls,
             patch.object(
@@ -672,7 +678,11 @@ class TestReportTypes:
             mock_store.list_entries.return_value = sample_entries
             mock_kb_cls.return_value = mock_store
 
-            _call_report("medical-research", report_type="standard", custom_instructions="Focus on safety.")
+            _call_report(
+                "medical-research",
+                report_type="standard",
+                custom_instructions="Focus on safety.",
+            )
 
         args = mock_exec.call_args.args
         instructions = args[3] if len(args) > 3 else ""

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -192,6 +192,10 @@ class TestGenerateReport:
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
             ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
+            ),
         ):
             mock_store = MagicMock()
             mock_store.list_entries.return_value = sample_entries
@@ -247,6 +251,10 @@ class TestGenerateReport:
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
             ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
+            ),
         ):
             mock_store = MagicMock()
             mock_store.list_entries.return_value = sample_entries
@@ -283,6 +291,10 @@ class TestGenerateReport:
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
             ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
+            ),
         ):
             mock_store = MagicMock()
             mock_store.list_entries.return_value = sample_entries
@@ -310,6 +322,10 @@ class TestGenerateReport:
             patch("autoinfo.output.KBStore") as mock_kb_cls,
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
+            ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
             ),
         ):
             mock_store = MagicMock()
@@ -339,6 +355,10 @@ class TestGenerateReport:
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
             ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
+            ),
         ):
             mock_store = MagicMock()
             mock_store.list_entries.return_value = sample_entries
@@ -363,6 +383,10 @@ class TestGenerateReport:
             patch("autoinfo.output.KBStore") as mock_kb_cls,
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
+            ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
             ),
         ):
             mock_store = MagicMock()
@@ -391,6 +415,10 @@ class TestGenerateReport:
             patch("autoinfo.output.KBStore") as mock_kb_cls,
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
+            ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
             ),
         ):
             mock_store = MagicMock()
@@ -428,6 +456,10 @@ class TestReportTypes:
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
             ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
+            ),
         ):
             mock_store = MagicMock()
             mock_store.list_entries.return_value = sample_entries
@@ -462,6 +494,10 @@ class TestReportTypes:
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
             ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
+            ),
         ):
             mock_store = MagicMock()
             mock_store.list_entries.return_value = sample_entries
@@ -488,6 +524,10 @@ class TestReportTypes:
             patch("autoinfo.output.KBStore") as mock_kb_cls,
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
+            ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
             ),
         ):
             mock_store = MagicMock()
@@ -516,6 +556,10 @@ class TestReportTypes:
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
             ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
+            ),
         ):
             mock_store = MagicMock()
             mock_store.list_entries.return_value = sample_entries
@@ -542,6 +586,10 @@ class TestReportTypes:
             patch("autoinfo.output.KBStore") as mock_kb_cls,
             patch.object(
                 _get_llm_extractor_class(), "extract", mock_extract
+            ),
+            patch(
+                "autoinfo.output._call_llm_for_report_synthesis",
+                return_value="",
             ),
         ):
             mock_store = MagicMock()

--- a/tests/test_v1_5_delivery.py
+++ b/tests/test_v1_5_delivery.py
@@ -574,7 +574,9 @@ class TestDigestDeliveryGates:
             # TRIAGE #35 — generate_report calls list_entries positionally
             # (output/__init__.py:2808: kb_store.list_entries(domain, limit=5000)),
             # so the mock signature must accept positional domain/limit too.
-            def list_entries(self, domain=None, limit=20, **kwargs: object) -> list[dict[str, object]]:
+            def list_entries(
+                self, domain=None, limit=20, **kwargs: object
+            ) -> list[dict[str, object]]:
                 return [
                     {
                         "entry_id": "e1",
@@ -615,7 +617,9 @@ class TestDigestDeliveryGates:
         class _MockStore:
             # TRIAGE #35 — same positional list_entries signature as the
             # other report-path mock (generate_report, output/__init__.py:2808).
-            def list_entries(self, domain=None, limit=20, **kwargs: object) -> list[dict[str, object]]:
+            def list_entries(
+                self, domain=None, limit=20, **kwargs: object
+            ) -> list[dict[str, object]]:
                 return [
                     {
                         "entry_id": "e1",

--- a/tests/test_v1_5_delivery.py
+++ b/tests/test_v1_5_delivery.py
@@ -592,6 +592,10 @@ class TestDigestDeliveryGates:
         monkeypatch.setattr("autoinfo.output.KBStore", lambda: _MockStore())
         # Mock LLM calls used by _group_by_theme and _generate_executive_summary
         monkeypatch.setattr(
+            "autoinfo.output._call_llm_for_report_synthesis",
+            lambda prompt: "",
+        )
+        monkeypatch.setattr(
             "autoinfo.output._llm_json_extract",
             lambda extractor, prompt, field: (
                 [{"theme": "General", "description": "All entries", "entry_ids": ["e1"]}]
@@ -629,6 +633,10 @@ class TestDigestDeliveryGates:
                 ]
 
         monkeypatch.setattr("autoinfo.output.KBStore", lambda: _MockStore())
+        monkeypatch.setattr(
+            "autoinfo.output._call_llm_for_report_synthesis",
+            lambda prompt: "",
+        )
         monkeypatch.setattr(
             "autoinfo.output._llm_json_extract",
             lambda extractor, prompt, field: (

--- a/tests/test_validation_delivery.py
+++ b/tests/test_validation_delivery.py
@@ -676,11 +676,18 @@ def test_enduser_journey_scenario_loads():
 
 
 def _required_cells() -> set[tuple[str, str, str]]:
-    """The spec's required domain x product x format cells (Oracle R8)."""
+    """The spec's required-capability domain x product x format cells
+    (Oracle R8) — required cells annotated ``capability: not-implemented``
+    are capability boundaries (rendered 不适用not-applicable, never 空gap),
+    so they are excluded from the gap-domain set."""
     spec = yaml.safe_load(
         (ROOT / "docs" / "dev" / "specs" / "end-user-matrix.yaml").read_text(encoding="utf-8")
     )
-    return {(c["domain"], c["product"], c["format"]) for c in spec["required_cells"]}
+    return {
+        (c["domain"], c["product"], c["format"])
+        for c in spec["required_cells"]
+        if c.get("capability", "implemented") == "implemented"
+    }
 
 
 def _zip_matrix_meta(zip_path: Path) -> dict[str, Any]:


### PR DESCRIPTION
## 内容

rebase 到最新 origin/main 后的 9 个 commit（昨晚工作补推）：

### 产物质量（output）
- **fix(output): feed actual entry content into report synthesis prompt** — report 合成 prompt 喂真实条目内容
- **fix(output): report gains Key Findings / Recommendations sections** — report 补 Key Findings / Recommendations
- **fix(output): chunk theme grouping + keyword fallback** — 长条目列表分批分组，防 General collapse
- **fix(output): tutorial generation robust to unstructured LLM output** — tutorial 容忍非结构化 LLM 输出

### 验证/验收（validation）
- **feat(validation): restore full 112-cell matrix spec with capability annotations; merge 11 demo domains**
- **feat(validation): product content-quality audit script (end-user view)** + **content-quality audit + retry scripts**
- **fix(validation): D1 recognizes enterprise/premium/magazine-digest briefing types**
- **fix(validation): D1 report requires only summary (no Key Findings headings in report template)**

## 测试
- `pytest tests/output/ tests/test_validation_delivery.py` → **146 passed, 1 skipped**
