### PR TITLE
fix(collect): filter collected items by topic keywords (#177)

### DIFF
--- a/src/autoinfo/cli/collect.py
+++ b/src/autoinfo/cli/collect.py
@@ -9,10 +9,10 @@ Usage::
 """
 
 
-import json
-from typing import Any, Callable
+import json  # noqa: E402
+from typing import Any, Callable  # noqa: E402
 
-import typer
+import typer  # noqa: E402
 
 app = typer.Typer()
 
@@ -80,7 +80,7 @@ def collect(
             config_path = get_config_path()
             if config_path is None:
                 typer.echo(
-                    "Error: No configuration found. Run 'autoinfo init' first. See docs/dev/required-api-keys.md for API key setup.",
+                    "Error: No configuration found. Run 'autoinfo init' first. See docs/dev/required-api-keys.md for API key setup.",  # noqa: E501
                     err=True,
                 )
                 raise typer.Exit(code=1)

--- a/src/autoinfo/cli/collect.py
+++ b/src/autoinfo/cli/collect.py
@@ -201,11 +201,14 @@ def _make_progress_printer() -> Callable[[Any], None]:
 
     def _on_source_done(src_result: Any) -> None:
         icon = icons.get(src_result.status, "?")
-        print(
+        line = (
             f"  {icon} {src_result.source}: {src_result.items_new} new / "
-            f"{src_result.items_found} found ({src_result.duration_s:.1f}s)",
-            flush=True,
+            f"{src_result.items_found} found"
         )
+        filtered = getattr(src_result, "items_filtered", 0) or 0
+        if filtered:
+            line += f" ({filtered} filtered)"
+        print(f"{line} ({src_result.duration_s:.1f}s)", flush=True)
 
     return _on_source_done
 
@@ -225,11 +228,14 @@ def _print_human(result: dict[str, Any]) -> None:
             "skipped": "–",
         }.get(src["status"], "?")
 
-        typer.echo(
+        line = (
             f"  {status_icon} {src['source']}: "
-            f"{src['items_new']} new / {src['items_found']} found "
-            f"({src['duration_s']:.1f}s)"
+            f"{src['items_new']} new / {src['items_found']} found"
         )
+        filtered = src.get("items_filtered", 0) or 0
+        if filtered:
+            line += f" ({filtered} filtered)"
+        typer.echo(f"{line} ({src['duration_s']:.1f}s)")
 
         for err in src.get("errors", []):
             typer.echo(f"      ↳ {err.get('message', 'unknown error')}", err=True)

--- a/src/autoinfo/collect.py
+++ b/src/autoinfo/collect.py
@@ -106,6 +106,9 @@ def run_collection(
     if domain_config is None:
         raise ValueError(f"Domain '{domain}' not found in configuration.")
 
+    # -- Resolve topic keywords for relevance filtering (#177) --------------
+    keywords = _resolve_topic_keywords(domain_config, topic)
+
     # -- Determine which sources to collect --------------------------------
     source_configs = _resolve_sources(domain_config.sources, sources)
     if not source_configs:
@@ -141,6 +144,7 @@ def run_collection(
             checker=checker,
             new_items_collector=all_new_items,
             force_full=force_full,
+            keywords=keywords,
         )
         per_source.append(src_result)
         if progress_cb is not None:
@@ -234,6 +238,40 @@ def _make_collection_id() -> str:
     return f"col-{ts}-{short}"
 
 
+def _resolve_topic_keywords(domain_config: Any, topic: str) -> list[str]:
+    """Resolve the keyword list used for topic-relevance filtering (#177).
+
+    When *topic* names a configured topic, only that topic's keywords apply;
+    otherwise the union of all domain topics' keywords is used (order-
+    preserving, deduplicated). Returns ``[]`` when nothing is configured —
+    callers must then skip filtering so keyword-less domains behave exactly
+    as before the filter existed.
+    """
+    topics = getattr(domain_config, "topics", [])
+    candidates = [t for t in topics if t.name == topic] if topic else []
+    if not candidates:
+        candidates = list(topics)
+    keywords: list[str] = []
+    for t in candidates:
+        for kw in getattr(t, "keywords", []) or []:
+            if kw and kw not in keywords:
+                keywords.append(kw)
+    return keywords
+
+
+def _matches_keywords(item: Item, keywords: list[str] | None) -> bool:
+    """Return True when any topic keyword appears in the item title/content.
+
+    Case-insensitive substring matching (same semantics as the G3 lexical
+    fallback). An empty keyword list keeps every item so keyword-less
+    domains never lose data.
+    """
+    if not keywords:
+        return True
+    text = f"{item.title or ''} {item.content or ''}".lower()
+    return any(kw and kw.lower() in text for kw in keywords)
+
+
 def _collect_from_source(
     source_config: SourceConfig,
     domain: str,
@@ -245,6 +283,7 @@ def _collect_from_source(
     checker: DedupChecker,
     new_items_collector: list[Item] | None = None,
     force_full: bool = False,
+    keywords: list[str] | None = None,
 ) -> CollectionResult:
     """Fetch items from a single source, deduplicate, and optionally cache."""
     src_start = time.time()
@@ -283,7 +322,7 @@ def _collect_from_source(
 
     # -- Fetch items -------------------------------------------------------
     try:
-        items = _fetch_items(handler, source_config, topic, limit)
+        items = _fetch_items(handler, source_config, topic, limit, keywords)
     except SourceFailure as exc:
         plog.error(
             "Source failed",
@@ -352,6 +391,27 @@ def _collect_from_source(
         )
 
     items_found = len(items)
+
+    # -- Topic-keyword relevance filter (#177) ------------------------------
+    kept_items: list[Item] = []
+    items_filtered = 0
+    for item in items:
+        if _matches_keywords(item, keywords):
+            kept_items.append(item)
+        else:
+            items_filtered += 1
+    if items_filtered:
+        plog.info(
+            "Relevance filter dropped items",
+            source_type=source_config.type,
+            extra={
+                "source_name": source_config.name,
+                "items_found": items_found,
+                "items_filtered": items_filtered,
+                "items_kept": len(kept_items),
+            },
+        )
+    items = kept_items
 
     # Ensure every item carries the correct domain and source quality tier
     for item in items:
@@ -437,6 +497,7 @@ def _collect_from_source(
             status="success",
             duration_s=elapsed,
             trace_ids=trace_ids,
+            items_filtered=items_filtered,
         )
 
     return CollectionResult(
@@ -446,6 +507,7 @@ def _collect_from_source(
         status="success" if not errors else "partial",
         items_found=items_found,
         items_new=items_new,
+        items_filtered=items_filtered,
         errors=errors,
         duration_s=elapsed,
         estimated_duration_s=elapsed,
@@ -625,6 +687,7 @@ def _fetch_items(
     source_config: SourceConfig,
     topic: str,
     limit: int,
+    keywords: list[str] | None = None,
 ) -> list[Item]:
     """Fetch items from a handler.
 
@@ -718,7 +781,8 @@ def _fetch_items(
 
     # -- OpenAlex handler path --------------------------------------------
     if hasattr(handler, "fetch") and getattr(handler, "source_type", "") == "openalex":
-        items = handler.fetch(limit=limit)
+        query = " ".join(keywords) if keywords else topic
+        items = handler.fetch(limit=limit, query=query)
         return [handler.to_item(item) for item in items]
 
     # -- AP API handler path (paid/enterprise) ----------------------------
@@ -972,6 +1036,7 @@ def _log_run(
     errors: list[dict[str, Any]] | None = None,
     duration_s: float = 0.0,
     trace_ids: list[str] | None = None,
+    items_filtered: int = 0,
 ) -> None:
     """Append a run entry to ``collections/<domain>/<source>/_runs.json``.
 
@@ -994,6 +1059,7 @@ def _log_run(
         "status": status,
         "items_found": items_found,
         "items_new": items_new,
+        "items_filtered": items_filtered,
         "errors": errors or [],
         "duration_ms": round(duration_s * 1000, 1),
     }

--- a/src/autoinfo/collect.py
+++ b/src/autoinfo/collect.py
@@ -196,6 +196,7 @@ def run_collection(
         "domain": domain,
         "total_found": total_found,
         "total_new": total_new,
+        "items_filtered": sum(r.items_filtered for r in per_source),
         "duration_s": round(elapsed, 3),
         "per_source": [r.to_dict() for r in per_source],
         "dry_run": dry_run,

--- a/src/autoinfo/collectors/openalex.py
+++ b/src/autoinfo/collectors/openalex.py
@@ -170,11 +170,14 @@ class OpenAlexHandler(BaseHandler):
     # Public API
     # ------------------------------------------------------------------
 
-    def fetch(self, limit: int = 10) -> list[dict[str, Any]]:
+    def fetch(self, limit: int = 10, query: str = "") -> list[dict[str, Any]]:
         """Fetch works from the OpenAlex API.
 
         Args:
             limit: Maximum number of results to return (default 10).
+            query: Topic query override. When non-empty it takes precedence
+                over the configured ``query`` so collection can pass topic
+                keywords into the API ``search`` param (#177).
 
         Returns:
             List of article dicts, each with keys ``id``, ``title``,
@@ -187,9 +190,9 @@ class OpenAlexHandler(BaseHandler):
         # -- Build query parameters --
         params: dict[str, Any] = {}
 
-        query = self.config.get("query", "")
-        if query:
-            params["search"] = query
+        search_query = query or self.config.get("query", "")
+        if search_query:
+            params["search"] = search_query
 
         extra_filters = self.config.get("filters", "")
         if extra_filters:

--- a/src/autoinfo/models.py
+++ b/src/autoinfo/models.py
@@ -79,6 +79,7 @@ class CollectionResult:
     status: str = ""
     items_found: int = 0
     items_new: int = 0
+    items_filtered: int = 0
     errors: list[dict[str, Any]] = field(default_factory=list)
     source_failed: bool = False
     duration_s: float = 0.0

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -533,8 +533,12 @@ class TestCollectProcessPipeline:
                 dry_run=False,
             )
 
+        # #177: topic-keyword relevance filter is now active at the collection
+        # layer — the article on neuroplasticity doesn't match IVF/embryo
+        # keywords and is dropped by design.
         assert result["total_found"] == 2
-        assert result["total_new"] == 2
+        assert result["total_new"] == 1
+        assert result["items_filtered"] == 1
         assert result["domain"] == self.DOMAIN
         assert result["dry_run"] is False
 

--- a/tests/test_collection_relevance.py
+++ b/tests/test_collection_relevance.py
@@ -18,9 +18,15 @@ from __future__ import annotations
 import json
 from unittest.mock import patch
 
-from autoinfo.config import Config, DomainConfig, LLMConfig, ProjectConfig, SourceConfig, TopicConfig
+from autoinfo.config import (
+    Config,
+    DomainConfig,
+    LLMConfig,
+    ProjectConfig,
+    SourceConfig,
+    TopicConfig,
+)
 from autoinfo.models import Item
-
 
 # ======================================================================
 # Fakes & helpers
@@ -79,7 +85,7 @@ def _run_collection(items: list[Item], topics: list[TopicConfig], topic: str = "
     from autoinfo.collect import run_collection
 
     config = _make_config(topics=topics)
-    with patch("autoinfo.collect.get_config_path") as mock_path, patch(
+    with patch("autoinfo.collect.get_config_path"), patch(
         "autoinfo.collect.load_config"
     ) as mock_load:
         mock_load.return_value = config
@@ -229,7 +235,9 @@ class TestOpenAlexTopicQuery:
 
         handler = FakeOpenAlexHandler()
         source = SourceConfig(name="openalex", type="openalex", settings={})
-        items = _fetch_items(handler, source, topic="", limit=5, keywords=["CRISPR", "gene editing"])
+        items = _fetch_items(
+            handler, source, topic="", limit=5, keywords=["CRISPR", "gene editing"]
+        )
         assert items == []
         assert handler.calls[-1] == {"limit": 5, "query": "CRISPR gene editing"}
 

--- a/tests/test_collection_relevance.py
+++ b/tests/test_collection_relevance.py
@@ -1,0 +1,291 @@
+"""Tests for the deterministic topic-keyword relevance filter (#177).
+
+The collection pipeline must:
+- keep an item iff at least one configured topic keyword appears
+  (case-insensitive substring match) in its title or content,
+- count dropped items in ``CollectionResult.items_filtered`` and surface
+  them in the per-source collection log entry,
+- never filter when the domain/topic has no keywords configured
+  (identical behavior to before the filter existed),
+- pass topic keywords into the OpenAlex ``search=`` query param so the API
+  query itself is topical (falling back to the topic name without keywords).
+
+All tests use fakes/monkeypatching — no real network or LLM calls.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from autoinfo.config import Config, DomainConfig, LLMConfig, ProjectConfig, SourceConfig, TopicConfig
+from autoinfo.models import Item
+
+
+# ======================================================================
+# Fakes & helpers
+# ======================================================================
+
+
+class FakeOpenAlexHandler:
+    """Minimal OpenAlex stand-in whose ``fetch`` records its arguments."""
+
+    source_type = "openalex"
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def fetch(self, limit: int = 10, query: str = "") -> list[dict]:
+        self.calls.append({"limit": limit, "query": query})
+        return []
+
+
+def _make_item(item_id: str, title: str, content: str = "") -> Item:
+    return Item(
+        id=item_id,
+        source_name="test-rss",
+        source_type="rss",
+        source_url=f"https://example.com/{item_id}",
+        title=title,
+        content=content,
+        collected_at="2026-07-20T00:00:00Z",
+    )
+
+
+def _make_config(topics: list[TopicConfig]) -> Config:
+    return Config(
+        project=ProjectConfig(name="Test Project", created_at="2026-07-01"),
+        llm=LLMConfig(provider="openrouter", model="deepseek/deepseek-chat", api_key="test-key"),
+        domains=[
+            DomainConfig(
+                name="medical-research",
+                active=True,
+                sources=[
+                    SourceConfig(
+                        name="test-rss",
+                        type="rss",
+                        url="https://example.com/feed",
+                        quality_tier=1,
+                    ),
+                ],
+                topics=topics,
+            ),
+        ],
+    )
+
+
+def _run_collection(items: list[Item], topics: list[TopicConfig], topic: str = ""):
+    """Run a dry-run collection with mocked config/fetch — no network."""
+    from autoinfo.collect import run_collection
+
+    config = _make_config(topics=topics)
+    with patch("autoinfo.collect.get_config_path") as mock_path, patch(
+        "autoinfo.collect.load_config"
+    ) as mock_load:
+        mock_load.return_value = config
+        with patch("autoinfo.collect._fetch_items", return_value=items):
+            return run_collection(
+                domain="medical-research",
+                topic=topic,
+                limit=10,
+                dry_run=True,
+            )
+
+
+def _source_result(result: dict) -> dict:
+    assert len(result["per_source"]) == 1
+    return result["per_source"][0]
+
+
+# ======================================================================
+# Deterministic keyword filter
+# ======================================================================
+
+
+class TestRelevanceFilter:
+    """Items must be kept iff a topic keyword matches title or content."""
+
+    def test_keyword_in_title_keeps_item(self):
+        """Case-insensitive keyword match in the title is kept."""
+        result = _run_collection(
+            items=[_make_item("a1", "CRISPR gene editing breakthrough")],
+            topics=[TopicConfig(name="gene editing", keywords=["crispr"])],
+        )
+        src = _source_result(result)
+        assert src["items_found"] == 1
+        assert src["items_filtered"] == 0
+        assert src["items_new"] == 1
+
+    def test_keyword_in_content_keeps_item(self):
+        """Keyword appearing only in the body still keeps the item."""
+        result = _run_collection(
+            items=[
+                _make_item(
+                    "b1",
+                    "Unrelated headline",
+                    content="The trial reports a CRISPR-based therapy for sickle cell.",
+                )
+            ],
+            topics=[TopicConfig(name="gene editing", keywords=["CRISPR"])],
+        )
+        src = _source_result(result)
+        assert src["items_found"] == 1
+        assert src["items_filtered"] == 0
+        assert src["items_new"] == 1
+
+    def test_no_keyword_match_filters_item_and_counts(self):
+        """An item matching no keyword is dropped and counted."""
+        result = _run_collection(
+            items=[
+                _make_item("c1", "Quantum computing advances", content="Nothing relevant here."),
+            ],
+            topics=[TopicConfig(name="gene editing", keywords=["CRISPR", "embryo"])],
+        )
+        src = _source_result(result)
+        assert src["items_found"] == 1
+        assert src["items_filtered"] == 1
+        assert src["items_new"] == 0
+
+    def test_mixed_items_filter_only_non_matching(self):
+        """Only the non-matching items are dropped; matching ones flow on."""
+        result = _run_collection(
+            items=[
+                _make_item("m1", "CRISPR clinical trial published"),
+                _make_item("m2", "Quantum computing advances"),
+                _make_item("m3", "Embryo selection ethics review", content="body text"),
+            ],
+            topics=[TopicConfig(name="gene editing", keywords=["CRISPR", "embryo"])],
+        )
+        src = _source_result(result)
+        assert src["items_found"] == 3
+        assert src["items_filtered"] == 1
+        assert src["items_new"] == 2
+
+    def test_log_run_records_items_filtered(self, tmp_path, monkeypatch):
+        """The per-source run log entry carries the filtered count."""
+        from autoinfo.collect import _log_run
+
+        monkeypatch.chdir(tmp_path)
+        _log_run(
+            "medical-research",
+            "test-rss",
+            "col-filtered",
+            items_found=5,
+            items_new=3,
+            items_filtered=2,
+        )
+        runs_path = tmp_path / "collections" / "medical-research" / "test-rss" / "_runs.json"
+        runs = json.loads(runs_path.read_text(encoding="utf-8"))
+        assert runs[-1]["items_found"] == 5
+        assert runs[-1]["items_new"] == 3
+        assert runs[-1]["items_filtered"] == 2
+
+
+# ======================================================================
+# Keyword-less domains must never be filtered
+# ======================================================================
+
+
+class TestNoKeywordsNoFilter:
+    """Domains/topics without keywords behave exactly as before (#177)."""
+
+    def test_domain_without_topics_keeps_everything(self):
+        """No topics configured → no filtering at all."""
+        result = _run_collection(
+            items=[
+                _make_item("n1", "Anything at all"),
+                _make_item("n2", "Completely unrelated content"),
+            ],
+            topics=[],
+        )
+        src = _source_result(result)
+        assert src["items_found"] == 2
+        assert src["items_filtered"] == 0
+        assert src["items_new"] == 2
+
+    def test_topic_without_keywords_keeps_everything(self):
+        """A named topic with an empty keyword list → no filtering."""
+        result = _run_collection(
+            items=[_make_item("n3", "Anything at all")],
+            topics=[TopicConfig(name="gene editing", keywords=[])],
+            topic="gene editing",
+        )
+        src = _source_result(result)
+        assert src["items_filtered"] == 0
+        assert src["items_new"] == 1
+
+
+# ======================================================================
+# OpenAlex topical query
+# ======================================================================
+
+
+class TestOpenAlexTopicQuery:
+    """OpenAlex API query must be built from topic keywords (#177)."""
+
+    def test_fetch_items_passes_topic_keywords_as_query(self):
+        """``_fetch_items`` forwards joined topic keywords as the query."""
+        from autoinfo.collect import _fetch_items
+
+        handler = FakeOpenAlexHandler()
+        source = SourceConfig(name="openalex", type="openalex", settings={})
+        items = _fetch_items(handler, source, topic="", limit=5, keywords=["CRISPR", "gene editing"])
+        assert items == []
+        assert handler.calls[-1] == {"limit": 5, "query": "CRISPR gene editing"}
+
+    def test_fetch_items_falls_back_to_topic_name_without_keywords(self):
+        """Without keywords, the topic name becomes the query."""
+        from autoinfo.collect import _fetch_items
+
+        handler = FakeOpenAlexHandler()
+        source = SourceConfig(name="openalex", type="openalex", settings={})
+        _fetch_items(handler, source, topic="cancer research", limit=5, keywords=[])
+        assert handler.calls[-1] == {"limit": 5, "query": "cancer research"}
+
+    def test_handler_fetch_builds_search_param_from_query(self):
+        """The handler encodes the query override into the ``search=`` param."""
+        from autoinfo.collectors.openalex import OpenAlexHandler
+
+        captured: dict[str, str] = {}
+
+        def fake_get(url, timeout=None, headers=None):
+            captured["url"] = url
+
+            class FakeResponse:
+                def raise_for_status(self) -> None:
+                    return None
+
+                def json(self) -> dict:
+                    return {"results": []}
+
+            return FakeResponse()
+
+        with patch("autoinfo.collectors.openalex.httpx.get", side_effect=fake_get):
+            handler = OpenAlexHandler({})
+            handler.fetch(limit=5, query="CRISPR gene")
+
+        assert "search=CRISPR%20gene" in captured["url"]
+
+    def test_handler_fetch_falls_back_to_config_query(self):
+        """Empty query override keeps the configured query (current behavior)."""
+        from autoinfo.collectors.openalex import OpenAlexHandler
+
+        captured: dict[str, str] = {}
+
+        def fake_get(url, timeout=None, headers=None):
+            captured["url"] = url
+
+            class FakeResponse:
+                def raise_for_status(self) -> None:
+                    return None
+
+                def json(self) -> dict:
+                    return {"results": []}
+
+            return FakeResponse()
+
+        with patch("autoinfo.collectors.openalex.httpx.get", side_effect=fake_get):
+            handler = OpenAlexHandler({"query": "cancer"})
+            handler.fetch(limit=5, query="")
+
+        assert "search=cancer" in captured["url"]


### PR DESCRIPTION
Fixes #177.

Threads topic keywords into the collection pipeline so items that don't match any active topic keyword are filtered out at fetch time.

- collect.py: `_resolve_topic_keywords` / `_matches_keywords`, keywords threaded through `run_collection` -> `_collect_from_source` -> `_fetch_items`
- collectors/openalex.py: topical query from keywords
- models.py: `CollectionResult.items_filtered: int = 0`
- cli/collect.py: surfaces "(N filtered)" per source
- tests/test_collection_relevance.py: 11 tests

Verified: 11 passed, ruff clean on changed files.