### PR TITLE
fix(process): filter stopwords, add toggle and cap for auto-discovered keywords (#179)

### DIFF
--- a/src/autoinfo/config.py
+++ b/src/autoinfo/config.py
@@ -209,6 +209,10 @@ class DomainConfig:
     delivery_gates: dict[str, DeliveryGateConfig] = field(default_factory=dict)
     ttl_days: int = 90
     freshness_threshold: float = 0.5
+    # Keyword auto-discovery (#179): defaults keep pre-#179 behavior.
+    auto_keyword_discovery: bool = True
+    max_auto_keywords: int = 100
+    auto_keyword_min_length: int = 2
 
     def __post_init__(self):
         """Apply domain-specific TTL defaults for built-in demo domains."""
@@ -631,6 +635,11 @@ def _dict_to_config(raw: dict[str, Any]) -> Config:
                 webhook_urls=list(d.get("webhook_urls", [])),
                 quality_gates=domain_quality_gates,
                 delivery_gates=domain_delivery_gates,
+                auto_keyword_discovery=_as_bool(
+                    d.get("auto_keyword_discovery", True)
+                ),
+                max_auto_keywords=int(d.get("max_auto_keywords", 100)),
+                auto_keyword_min_length=int(d.get("auto_keyword_min_length", 2)),
             )
         )
 
@@ -1099,6 +1108,12 @@ def config_to_dict(config: Config) -> dict[str, Any]:
             domain_dict["extract_fields"] = domain.extract_fields
         if domain.search_mode != "keyword":
             domain_dict["search_mode"] = domain.search_mode
+        if not domain.auto_keyword_discovery:
+            domain_dict["auto_keyword_discovery"] = False
+        if domain.max_auto_keywords != 100:
+            domain_dict["max_auto_keywords"] = domain.max_auto_keywords
+        if domain.auto_keyword_min_length != 2:
+            domain_dict["auto_keyword_min_length"] = domain.auto_keyword_min_length
         if domain.webhook_urls:
             domain_dict["webhook_urls"] = domain.webhook_urls
         if domain.quality_gates:

--- a/src/autoinfo/process.py
+++ b/src/autoinfo/process.py
@@ -135,7 +135,7 @@ def detect_language(text: str) -> str:
     if len(text.strip()) < 20:
         return "unknown"
     try:
-        from langdetect import LangDetectException as _LDE
+        from langdetect import LangDetectException as _LDE  # noqa: N814
         from langdetect import detect_langs
     except ImportError:
         logger.debug("langdetect not installed — language detection disabled")
@@ -297,7 +297,7 @@ def _read_progress(domain: str) -> dict:
         with sqlite3.connect(str(db_path)) as conn:
             _init_progress_table(conn)
             row = conn.execute(
-                "SELECT last_processed_index, total_items FROM processing_progress WHERE domain = ?",
+                "SELECT last_processed_index, total_items FROM processing_progress WHERE domain = ?",  # noqa: E501
                 (domain,),
             ).fetchone()
             if row is not None:
@@ -655,7 +655,7 @@ def run_processing(
     from dataclasses import fields as _dc_fields
 
     from autoinfo.models import KBEntry
-    _KB_FIELDS = {f.name for f in _dc_fields(KBEntry)}
+    _KB_FIELDS = {f.name for f in _dc_fields(KBEntry)}  # noqa: N806
     existing_entries_raw = kb_store.list_entries(domain, limit=10000)
     existing_entries: list[KBEntry] = [
         KBEntry(**{k: v for k, v in row.items() if k in _KB_FIELDS})
@@ -857,7 +857,7 @@ def run_processing(
                     )
                     g4_model = f"{g4_provider}/{g4_model_name}"
                     g4_gate_config = gate_config.get("G4-SummaryFactual") if gate_config else None
-                    g4 = G4FactualConsistency(model=g4_model, json_mode=proc_config.llm.json_mode if proc_config else False, timeout=llm_timeout)
+                    g4 = G4FactualConsistency(model=g4_model, json_mode=proc_config.llm.json_mode if proc_config else False, timeout=llm_timeout)  # noqa: E501
                     g4_result = g4.check(item, extraction, gate_config=g4_gate_config)
                     quality_results["G4-SummaryFactual"] = g4_result
 

--- a/src/autoinfo/process.py
+++ b/src/autoinfo/process.py
@@ -24,8 +24,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from autoinfo.config import Config, QualityGateConfig, get_config_path, load_config
-from autoinfo.kb import KBStore, PromotionRejected
+from autoinfo.config import Config, DomainConfig, QualityGateConfig, get_config_path, load_config
+from autoinfo.kb import _FTS5_STOPWORDS, KBStore, PromotionRejected
 from autoinfo.keywords import KeywordsFile, KeywordState
 from autoinfo.llm import LLMExtractor
 from autoinfo.models import Item
@@ -45,13 +45,39 @@ from autoinfo.quality import (
 logger = logging.getLogger(__name__)
 
 # Minimal stop sets for keyword auto-discovery (Step e in processing pipeline)
+# — augmented with the richer FTS5 stopword list from kb.py.
 _STOP_WORDS: frozenset[str] = frozenset({
     "the", "this", "that", "with", "from", "have", "been", "were",
     "their", "which", "about", "study", "also", "show", "shown",
     "using", "used", "may", "results", "result", "method", "methods",
     "however", "conclusion", "background", "objective", "aim",
-})
+}) | _FTS5_STOPWORDS
 _STOP_PHRASES: frozenset[str] = frozenset({"", "  ", "   "})
+
+
+def _is_valid_discovery_keyword(candidate: str, min_length: int = 2) -> bool:
+    """Return ``True`` when *candidate* is fit for keyword auto-discovery.
+
+    A candidate passes when, after trimming and lower-casing, it is at
+    least ``min_length`` chars, contains at least one letter, and is not
+    a stopword or a stopword-only phrase.  Multi-word candidates are
+    additionally rejected when any constituent word is digit/punctuation
+    only (e.g. ``"results 2024"``).
+    """
+    text = candidate.strip().lower()
+    if not text or len(text) < min_length:
+        return False
+    if text in _STOP_PHRASES or text in _STOP_WORDS:
+        return False
+    if not any(ch.isalpha() for ch in text):
+        return False
+    words = text.split()
+    if len(words) > 1:
+        if any(not any(ch.isalpha() for ch in w) for w in words):
+            return False
+        if all(w in _STOP_WORDS for w in words):
+            return False
+    return True
 
 # Parallel processing (issue #136): LLM extraction dominates per-item latency,
 # so items are processed concurrently in a bounded thread pool.  Default 5
@@ -627,6 +653,7 @@ def run_processing(
     # return extra columns (created_at, cefr, etc.) that KBEntry doesn't
     # accept as constructor args.
     from dataclasses import fields as _dc_fields
+
     from autoinfo.models import KBEntry
     _KB_FIELDS = {f.name for f in _dc_fields(KBEntry)}
     existing_entries_raw = kb_store.list_entries(domain, limit=10000)
@@ -665,6 +692,16 @@ def run_processing(
         for d in config.domains:
             if d.name == domain:
                 gate_config.update(d.quality_gates)
+                break
+
+    # Resolve the domain config for keyword auto-discovery (#179): toggle,
+    # AUTO_ADDED cap and minimum candidate length.  Defaults (on / 100 / 2)
+    # apply when the domain omits the fields, preserving pre-#179 behavior.
+    domain_cfg: DomainConfig | None = None
+    if config:
+        for d in config.domains:
+            if d.name == domain:
+                domain_cfg = d
                 break
 
     # Resolve source quality tiers from domain config (for G1 propagation)
@@ -944,7 +981,9 @@ def run_processing(
                             )
                         else:
                             # Pre-checks pass → run LLM judge (gate 5)
-                            from autoinfo.translation_qa import calculate_quality_score  # noqa: PLC0415
+                            from autoinfo.translation_qa import (
+                                calculate_quality_score,  # noqa: PLC0415
+                            )
 
                             g5_scores = llm_judge(
                                 source_text, target_text,
@@ -1136,24 +1175,26 @@ def run_processing(
             # thread) because KeywordsFile is not thread-safe.
             discovered: list[str] = []
             if extraction:
+                min_len = (
+                    domain_cfg.auto_keyword_min_length if domain_cfg else 2
+                )
                 # Collect entity names as keyword candidates
                 for entity in extraction.entities:
                     name = entity.get("name", "").strip().lower()
-                    if name and len(name) > 1:
+                    if _is_valid_discovery_keyword(name, min_length=min_len):
                         discovered.append(name)
                 # Collect key-point phrases as keyword candidates
                 for kp in extraction.key_points:
                     words = [w.strip().lower() for w in kp.split() if len(w.strip()) > 2]
                     # Use short phrases (2-4 words) as single keywords
                     for i in range(len(words)):
-                        # Single words that aren't stop-word-ish
                         w = words[i]
-                        if len(w) > 3 and w not in _STOP_WORDS:
+                        if _is_valid_discovery_keyword(w, min_length=min_len):
                             discovered.append(w)
                     for n in (2, 3):
                         phrases = [" ".join(words[i:i + n]) for i in range(len(words) - n + 1)]
                         for p in phrases:
-                            if p not in _STOP_PHRASES:
+                            if _is_valid_discovery_keyword(p, min_length=min_len):
                                 discovered.append(p)
 
             if discovered:
@@ -1230,17 +1271,43 @@ def run_processing(
             result.passed_gates += stats["passed_gates"]
             result.errors.extend(stats["errors"])
 
-            # Keyword auto-discovery writes (single-threaded — file I/O)
-            for kw, source_name in stats["discovered"]:
-                try:
-                    kf.add_keyword(
-                        domain=domain,
-                        keyword=kw,
-                        state=KeywordState.AUTO_ADDED,
-                        source=f"auto-discovery:{source_name}",
-                    )
-                except Exception:
-                    logger.debug("Failed to add discovered keyword '%s':", kw, exc_info=True)
+            # Keyword auto-discovery writes (single-threaded — file I/O).
+            # Toggle + cap (#179): when disabled nothing is written; once the
+            # domain's AUTO_ADDED count reaches the cap, further new keywords
+            # are skipped (never an error).
+            discovery_enabled = (
+                domain_cfg.auto_keyword_discovery if domain_cfg else True
+            )
+            max_auto = domain_cfg.max_auto_keywords if domain_cfg else 100
+            if discovery_enabled and stats["discovered"]:
+                entries = kf.load(domain)
+                existing = {e.keyword: e for e in entries}
+                auto_count = sum(
+                    1 for e in entries if e.state == KeywordState.AUTO_ADDED
+                )
+                for kw, source_name in stats["discovered"]:
+                    current = existing.get(kw)
+                    if current is None:
+                        if auto_count >= max_auto:
+                            continue
+                        auto_count += 1
+                    elif current.state != KeywordState.AUTO_ADDED:
+                        # Re-adding a non-AUTO_ADDED keyword flips it to
+                        # AUTO_ADDED, which consumes cap budget too.
+                        if auto_count >= max_auto:
+                            continue
+                        auto_count += 1
+                    try:
+                        stored = kf.add_keyword(
+                            domain=domain,
+                            keyword=kw,
+                            state=KeywordState.AUTO_ADDED,
+                            source=f"auto-discovery:{source_name}",
+                        )
+                    except Exception:
+                        logger.debug("Failed to add discovered keyword '%s':", kw, exc_info=True)
+                        continue
+                    existing[kw] = stored
 
             # Per-item progress output — flushed so it survives a killed run
             if progress_enabled:

--- a/tests/test_process_keywords.py
+++ b/tests/test_process_keywords.py
@@ -23,12 +23,11 @@ import pytest
 
 from autoinfo.config import Config, DomainConfig, config_to_dict, load_config
 from autoinfo.kb import KBStore
-from autoinfo.keywords import KeywordState, KeywordsFile
+from autoinfo.keywords import KeywordsFile, KeywordState
 from autoinfo.llm import LLMExtractor
 from autoinfo.models import ExtractionResult, Item, KBEntry
 from autoinfo.process import run_processing
 from autoinfo.quality import QualityResult
-
 
 # ===================================================================
 # Fixtures / helpers

--- a/tests/test_process_keywords.py
+++ b/tests/test_process_keywords.py
@@ -1,0 +1,407 @@
+"""Tests for keyword auto-discovery hygiene (issue #179).
+
+Covers the auto-discovery step of the processing pipeline:
+
+- Junk candidates (stopwords, single characters, digits, punctuation,
+  stopword-only phrases) are never written to the domain keyword store
+- Valid candidates are still discovered and written (AUTO_ADDED)
+- ``DomainConfig.auto_keyword_discovery = False`` disables the writes
+- ``DomainConfig.max_auto_keywords`` caps the number of AUTO_ADDED
+  keywords per domain (skip, never an error)
+- Defaults preserve pre-#179 behavior for existing configs
+
+All LLM calls are mocked — no real API calls are made.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from autoinfo.config import Config, DomainConfig, config_to_dict, load_config
+from autoinfo.kb import KBStore
+from autoinfo.keywords import KeywordState, KeywordsFile
+from autoinfo.llm import LLMExtractor
+from autoinfo.models import ExtractionResult, Item, KBEntry
+from autoinfo.process import run_processing
+from autoinfo.quality import QualityResult
+
+
+# ===================================================================
+# Fixtures / helpers
+# ===================================================================
+
+DOMAIN = "kw-test"
+
+
+def _item(item_id: str) -> Item:
+    """Return a minimal synthetic item for keyword discovery tests."""
+    return Item(
+        id=item_id,
+        source_name="pubmed",
+        source_type="api",
+        source_platform="pubmed",
+        source_url=f"https://example.com/{item_id}",
+        title="Test article",
+        content="Test content.",
+        content_type="text",
+        collected_at="2026-07-15T10:00:00Z",
+        language="en",
+        domain=DOMAIN,
+        topic_tags=[],
+        quality_tier=1,
+        raw_data={},
+    )
+
+
+def _make_quality_results_all_pass() -> dict[str, QualityResult]:
+    """Return quality gate results where all three gates pass."""
+    return {
+        "G1-SourceAuthority": QualityResult(
+            gate_name="G1-SourceAuthority", passed=True, score=1.0,
+            details={"quality_tier": 1, "source_name": "pubmed"},
+        ),
+        "G2-Dedup": QualityResult(
+            gate_name="G2-Dedup", passed=True, score=1.0,
+            details={"is_duplicate": False, "matched_by": None},
+        ),
+        "G3-RelevanceScoring": QualityResult(
+            gate_name="G3-RelevanceScoring", passed=True, score=85.0,
+            details={"hidden": False},
+        ),
+    }
+
+
+def _run(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    items: list[Item],
+    extraction: ExtractionResult,
+    config: Config | None = None,
+):
+    """Run the processing pipeline with a mocked LLM and isolated cwd.
+
+    ``chdir`` to *tmp_path* so the real ``KeywordsFile`` (default base dir
+    is the cwd) writes to ``tmp_path/knowledge/<domain>/_keywords.yaml``.
+    When *config* is provided, ``get_config_path``/``load_config`` are
+    patched so the pipeline picks it up; otherwise no config exists and
+    the pre-#179 defaults apply.
+    """
+    monkeypatch.chdir(tmp_path)
+    mock_store = MagicMock(spec=KBStore)
+    mock_store.store_entry.return_value = KBEntry(
+        entry_id="test", title="test", domain=DOMAIN
+    )
+    mock_store.list_entries.return_value = []
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch("autoinfo.process.load_cached_items", return_value=items)
+        )
+        stack.enter_context(
+            patch.object(
+                LLMExtractor,
+                "extract",
+                MagicMock(return_value=extraction),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "autoinfo.process.run_quality_gates",
+                MagicMock(return_value=_make_quality_results_all_pass()),
+            )
+        )
+        stack.enter_context(
+            patch("autoinfo.process.KBStore", return_value=mock_store)
+        )
+        if config is not None:
+            stack.enter_context(
+                patch(
+                    "autoinfo.process.get_config_path",
+                    return_value=tmp_path / ".autoinfo" / "config.yaml",
+                )
+            )
+            stack.enter_context(
+                patch("autoinfo.process.load_config", return_value=config)
+            )
+        return run_processing(DOMAIN)
+
+
+def _extraction(
+    item_id: str = "item-001",
+    key_points: list[str] | None = None,
+    entities: list[dict] | None = None,
+) -> ExtractionResult:
+    return ExtractionResult(
+        item_id=item_id,
+        title="Test article",
+        tl_dr="A test article.",
+        key_points=key_points or [],
+        entities=entities or [],
+        relevance_score=85.0,
+    )
+
+
+def _keywords(tmp_path: Path) -> list[str]:
+    """Return the keyword strings stored for the test domain."""
+    return [e.keyword for e in KeywordsFile(base_dir=tmp_path).load(DOMAIN)]
+
+
+# ===================================================================
+# (a) Junk candidates are never added by auto-discovery
+# ===================================================================
+
+
+class TestJunkCandidatesRejected:
+    """Stopwords, digits, punctuation and single chars are filtered out."""
+
+    def test_junk_not_added_and_valid_kept(self, monkeypatch, tmp_path: Path) -> None:
+        extraction = _extraction(
+            key_points=[
+                "the study",      # every word is a stopword
+                "results 2024",   # contains a digit-only token
+            ],
+            entities=[
+                {"name": "the", "type": "concept"},      # stopword
+                {"name": "2024", "type": "concept"},     # digits only
+                {"name": "!!", "type": "concept"},       # punctuation only
+                {"name": "a", "type": "concept"},        # single character
+                {"name": "CRISPR", "type": "technique"},  # valid
+            ],
+        )
+        _run(monkeypatch, tmp_path, [_item("item-001")], extraction)
+
+        keywords = _keywords(tmp_path)
+        assert "crispr" in keywords
+        for junk in ("the", "2024", "!!", "a", "the study", "results 2024"):
+            assert junk not in keywords
+
+    def test_all_written_entries_are_auto_added(self, monkeypatch, tmp_path: Path) -> None:
+        extraction = _extraction(
+            entities=[{"name": "CRISPR", "type": "technique"}],
+        )
+        _run(monkeypatch, tmp_path, [_item("item-001")], extraction)
+
+        entries = KeywordsFile(base_dir=tmp_path).load(DOMAIN)
+        assert len(entries) == 1
+        assert entries[0].keyword == "crispr"
+        assert entries[0].state == KeywordState.AUTO_ADDED
+        assert entries[0].source.startswith("auto-discovery:")
+
+
+class TestHygieneHelper:
+    """Unit tests for the shared ``_is_valid_discovery_keyword`` helper."""
+
+    @staticmethod
+    def _helper():
+        from autoinfo.process import _is_valid_discovery_keyword
+        return _is_valid_discovery_keyword
+
+    def test_rejects_junk_candidates(self) -> None:
+        helper = self._helper()
+        for junk in (
+            "the", "this", "with",           # stopwords
+            "the study", "results shown",    # stopword-only phrases
+            "2024", "42",                    # digits
+            "!!", "...", "???",              # punctuation
+            "a", "x",                        # too short (min_length=2)
+            "   ", "",                       # whitespace / empty
+            "results 2024",                  # digit-only token inside phrase
+        ):
+            assert not helper(junk), junk
+
+    def test_accepts_valid_candidates(self) -> None:
+        helper = self._helper()
+        for valid in (
+            "crispr", "gene editing", "climate change",
+            "machine learning", "ai", "ml", "dna",
+        ):
+            assert helper(valid), valid
+
+    def test_case_insensitive_stopwords(self) -> None:
+        helper = self._helper()
+        assert not helper("The")
+        assert not helper("  THE  ")
+
+    def test_min_length_knob(self) -> None:
+        helper = self._helper()
+        assert helper("ab", min_length=2)
+        assert not helper("ab", min_length=3)
+        assert helper("abc", min_length=3)
+
+
+# ===================================================================
+# (b) Valid candidate keywords ARE added (existing behavior preserved)
+# ===================================================================
+
+
+class TestValidCandidatesAdded:
+    """Real keywords from entity names and key points still get added."""
+
+    def test_valid_keywords_added(self, monkeypatch, tmp_path: Path) -> None:
+        extraction = _extraction(
+            key_points=[
+                "Machine learning improves outcomes",
+                "climate change research",
+            ],
+            entities=[
+                {"name": "CRISPR", "type": "technique"},
+                {"name": "gene editing", "type": "technique"},
+            ],
+        )
+        _run(monkeypatch, tmp_path, [_item("item-001")], extraction)
+
+        keywords = _keywords(tmp_path)
+        for expected in (
+            "crispr", "gene editing",
+            "machine", "learning",
+            "climate change", "machine learning",
+        ):
+            assert expected in keywords
+
+
+# ===================================================================
+# (c) Toggle: auto_keyword_discovery=False writes nothing
+# ===================================================================
+
+
+class TestDiscoveryToggle:
+    """``auto_keyword_discovery: false`` disables auto-discovery writes."""
+
+    def test_disabled_writes_no_keywords(self, monkeypatch, tmp_path: Path) -> None:
+        config = Config(
+            domains=[DomainConfig(name=DOMAIN, auto_keyword_discovery=False)]
+        )
+        extraction = _extraction(
+            entities=[
+                {"name": "CRISPR", "type": "technique"},
+                {"name": "gene editing", "type": "technique"},
+            ],
+        )
+        _run(monkeypatch, tmp_path, [_item("item-001")], extraction, config=config)
+
+        # Nothing written — the keywords file does not even exist.
+        assert KeywordsFile(base_dir=tmp_path).load(DOMAIN) == []
+
+
+# ===================================================================
+# (d) Cap: max_auto_keywords bounds AUTO_ADDED growth
+# ===================================================================
+
+
+class TestAutoKeywordCap:
+    """``max_auto_keywords`` caps AUTO_ADDED keyword growth (skip, no error)."""
+
+    def test_cap_limits_new_auto_keywords(self, monkeypatch, tmp_path: Path) -> None:
+        # Pre-seed 2 AUTO_ADDED keywords; cap is 3 → only 1 new keyword may
+        # be added, and later candidates must be skipped without error.
+        kf = KeywordsFile(base_dir=tmp_path)
+        kf.add_keyword(DOMAIN, "seed-0")
+        kf.add_keyword(DOMAIN, "seed-1")
+
+        config = Config(domains=[DomainConfig(name=DOMAIN, max_auto_keywords=3)])
+        extraction = _extraction(
+            entities=[
+                {"name": "k1", "type": "concept"},
+                {"name": "k2", "type": "concept"},
+                {"name": "k3", "type": "concept"},
+                {"name": "k4", "type": "concept"},
+                {"name": "k5", "type": "concept"},
+                {"name": "k6", "type": "concept"},
+            ],
+        )
+        result = _run(monkeypatch, tmp_path, [_item("item-001")], extraction, config=config)
+
+        entries = KeywordsFile(base_dir=tmp_path).load(DOMAIN)
+        auto = [e for e in entries if e.state == KeywordState.AUTO_ADDED]
+        assert len(auto) == 3  # 2 seeds + exactly 1 new
+        new_ones = {e.keyword for e in auto} - {"seed-0", "seed-1"}
+        assert new_ones == {"k1"}
+        # Skipped candidates are not an error — the run completes cleanly.
+        assert result.errors == []
+
+    def test_cap_reached_preexisting_adds_nothing(self, monkeypatch, tmp_path: Path) -> None:
+        kf = KeywordsFile(base_dir=tmp_path)
+        for i in range(3):
+            kf.add_keyword(DOMAIN, f"seed-{i}")
+
+        config = Config(domains=[DomainConfig(name=DOMAIN, max_auto_keywords=3)])
+        extraction = _extraction(
+            entities=[{"name": "k1", "type": "concept"}],
+        )
+        result = _run(monkeypatch, tmp_path, [_item("item-001")], extraction, config=config)
+
+        auto = [
+            e for e in KeywordsFile(base_dir=tmp_path).load(DOMAIN)
+            if e.state == KeywordState.AUTO_ADDED
+        ]
+        assert {e.keyword for e in auto} == {"seed-0", "seed-1", "seed-2"}
+        assert result.errors == []
+
+
+# ===================================================================
+# (e) Defaults: existing configs/domains behave as before
+# ===================================================================
+
+
+class TestDefaults:
+    """Configs without the new fields keep the pre-#179 behavior."""
+
+    def test_dataclass_defaults(self) -> None:
+        d = DomainConfig(name=DOMAIN)
+        assert d.auto_keyword_discovery is True
+        assert d.max_auto_keywords == 100
+        assert d.auto_keyword_min_length == 2
+
+    def test_yaml_without_new_fields_gets_defaults(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(
+            "domains:\n  - name: kw-test\n    active: true\n",
+            encoding="utf-8",
+        )
+        d = load_config(cfg_path).domains[0]
+        assert d.auto_keyword_discovery is True
+        assert d.max_auto_keywords == 100
+        assert d.auto_keyword_min_length == 2
+
+    def test_yaml_with_new_fields_is_parsed(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(
+            "domains:\n"
+            "  - name: kw-test\n"
+            "    auto_keyword_discovery: false\n"
+            "    max_auto_keywords: 5\n"
+            "    auto_keyword_min_length: 3\n",
+            encoding="utf-8",
+        )
+        d = load_config(cfg_path).domains[0]
+        assert d.auto_keyword_discovery is False
+        assert d.max_auto_keywords == 5
+        assert d.auto_keyword_min_length == 3
+        # Serialization round-trip keeps non-default values.
+        out = config_to_dict(Config(domains=[d]))
+        assert out["domains"][0]["auto_keyword_discovery"] is False
+        assert out["domains"][0]["max_auto_keywords"] == 5
+        assert out["domains"][0]["auto_keyword_min_length"] == 3
+
+    def test_no_config_still_discovers(self, monkeypatch, tmp_path: Path) -> None:
+        """No config file at all (config=None) → discovery runs with defaults."""
+        extraction = _extraction(
+            entities=[{"name": "CRISPR", "type": "technique"}],
+        )
+        _run(monkeypatch, tmp_path, [_item("item-001")], extraction)
+
+        assert "crispr" in _keywords(tmp_path)
+
+    def test_explicitly_enabled_matches_default(self, monkeypatch, tmp_path: Path) -> None:
+        config = Config(
+            domains=[DomainConfig(name=DOMAIN, auto_keyword_discovery=True)]
+        )
+        extraction = _extraction(
+            entities=[{"name": "CRISPR", "type": "technique"}],
+        )
+        _run(monkeypatch, tmp_path, [_item("item-001")], extraction, config=config)
+
+        assert "crispr" in _keywords(tmp_path)


### PR DESCRIPTION
Fixes #179.

- process.py: auto-discovered keywords drop `_STOP_WORDS`/`_STOP_PHRASES`, respect toggle (DomainConfig.auto_keyword_discovery) and cap (max_auto_keywords)
- config.py: `auto_keyword_discovery: bool = True`, `max_auto_keywords: int = 100`
- tests/test_process_keywords.py: 15 tests

Verified: 15 passed, ruff clean on changed files. Includes chore silencing 4 pre-existing lint errors in process.py (touched file must be gate-clean; matches b0c3f62 pattern).