### PR TITLE
chore: commit reusable validation assets (Q10-Q18 results, enduser scenario, q2b tests)

### DIFF
--- a/docs/autoinfo-validation-master-plan/part-02-cli-depth-results-q10-q18.md
+++ b/docs/autoinfo-validation-master-plan/part-02-cli-depth-results-q10-q18.md
@@ -1,0 +1,170 @@
+# Part 2 CLI Depth Scenarios — Q10–Q18 Results
+
+**Date:** 2026-07-31  
+**Model:** deepseek-v4-flash  
+**Environment:** WSL, AutoInfo project at `/mnt/d/Hermes-Workspace/01-Projects/AutoInfo`
+
+**Notes:**
+- Scenarios marked **SKIP** require LLM API key (not available) or SMTP config (not configured)
+- 50 total scenarios across 9 question groups
+- `collect` module has an import error (`cannot import name 'etree'` from lxml) affecting Q12/Q18
+
+---
+
+## Q10: CEFR Classification CLI
+
+| # | Scenario | Result | Detail |
+|---|----------|--------|--------|
+| 10.1 | Classify single text | ⏭️ SKIP | Requires LLM API key |
+| 10.2 | Batch classify from file | ⏭️ SKIP | Requires LLM API key |
+| 10.3 | Chinese classify | ⏭️ SKIP | Requires LLM API key |
+| 10.4 | Batch from stdin | ⏭️ SKIP | Requires LLM API key |
+| 10.5 | Classify --json | ⏭️ SKIP | Requires LLM API key |
+| 10.6 | Empty text error | ⚠️ WARN | Returns valid JSON `{cefr_level: unknown, confidence: 0.0}` — no crash/traceback, but also no user-friendly error message as spec expected |
+
+**Q10 Summary:** 0 PASS, 0 FAIL, 5 SKIP, 1 WARN
+
+---
+
+## Q11: Email CLI
+
+| # | Scenario | Result | Detail |
+|---|----------|--------|--------|
+| 11.1 | Email config show | ✅ PASS | Shows SMTP fields (all unconfigured) |
+| 11.2 | Send email digest | ⏭️ SKIP | Requires SMTP config |
+| 11.3 | Send without SMTP | ✅ PASS | "Email delivery is not enabled. Set 'email.enabled: true' in config." — friendly error, no traceback |
+| 11.4 | Email config --json | ⚠️ WARN | `--json` flag not supported on `email config` |
+
+**Q11 Summary:** 2 PASS, 0 FAIL, 1 SKIP, 1 WARN
+
+---
+
+## Q12: Cron/Schedule CLI
+
+| # | Scenario | Result | Detail |
+|---|----------|--------|--------|
+| 12.1 | List schedules | ✅ PASS | Shows schedule table (empty by default) |
+| 12.2 | Add schedule | ❌ FAIL | Error: schedule already exists (demo data pre-populates `weekly-ivf`) |
+| 12.3 | Remove schedule | ✅ PASS | Schedule `weekly-ivf` removed |
+| 12.4 | Run schedules | ❌ FAIL | Collect module has `ImportError: cannot import name 'etree'` from lxml — infrastructure issue |
+| 12.5 | Install crontab | ✅ PASS | Crontab entry installed |
+| 12.6 | Uninstall crontab | ✅ PASS | Crontab entries removed |
+| 12.7 | Cron health | ✅ PASS | Health table shows schedule status |
+| 12.8 | Health --json | ✅ PASS | Valid JSON with schedule health fields |
+| 12.9 | Add delivery | ⚠️ WARN | Validation plan uses wrong flags (`--name`, `--expression`, `--output-type`); actual CLI uses `--schedule`, `--output` and has no `--name`. Help shown correctly. |
+| 12.10 | List deliveries | ✅ PASS | "No delivery schedules configured" |
+
+**Q12 Summary:** 7 PASS, 2 FAIL, 0 SKIP, 1 WARN
+
+---
+
+## Q13: Keywords CLI
+
+| # | Scenario | Result | Detail |
+|---|----------|--------|--------|
+| 13.1 | List keywords | ✅ PASS | Shows "No keywords found" (no keywords file yet for demo) |
+| 13.2 | Approve keyword | ✅ PASS | "Keyword 'CRISPR' not found" — graceful handling of missing keyword |
+| 13.3 | Reject keyword | ✅ PASS | "Keyword 'CRISPR' not found" — graceful handling |
+| 13.4 | Keywords --help | ✅ PASS | Shows `list`, `approve`, `reject` subcommands |
+| 13.5 | Keywords --json | ⚠️ WARN | `--json` flag not supported on `keywords list` |
+| 13.6 | Nonexistent keyword | ✅ PASS | "Keyword 'NONEXISTENT_KEYWORD_12345' not found" — friendly error, no traceback |
+
+**Q13 Summary:** 5 PASS, 0 FAIL, 0 SKIP, 1 WARN
+
+---
+
+## Q14: Knowledge Graph CLI
+
+| # | Scenario | Result | Detail |
+|---|----------|--------|--------|
+| 14.1 | Graph export | ✅ PASS | Exported to `knowledge_graph_export.json` |
+| 14.2 | Graph --json | ⚠️ WARN | `--json` flag not supported on `knowledge graph export` |
+| 14.3 | Knowledge help | ✅ PASS | Shows `graph` subcommand; `graph --help` shows `export` |
+
+**Q14 Summary:** 2 PASS, 0 FAIL, 0 SKIP, 1 WARN
+
+---
+
+## Q15: Clean CLI
+
+| # | Scenario | Result | Detail |
+|---|----------|--------|--------|
+| 15.1 | Clean artifacts | ✅ PASS | "Nothing to clean." |
+| 15.2 | Clean --dry-run | ✅ PASS | "Would remove 0 item(s)." |
+| 15.3 | Clean --collections | ✅ PASS | Exit code 0 |
+| 15.4 | Clean --outputs | ✅ PASS | Exit code 0 |
+| 15.5 | Clean --everything --dry-run | ✅ PASS | "Would remove 0 item(s)." |
+
+**Q15 Summary:** 5 PASS, 0 FAIL, 0 SKIP, 0 WARN
+
+---
+
+## Q16: Global CLI Behavior
+
+| # | Scenario | Result | Detail |
+|---|----------|--------|--------|
+| 16.1 | --help on all commands | ✅ PASS | All 17 commands produce help, exit 0 |
+| 16.2 | Version (doctor --json) | ✅ PASS | Version available via `doctor --json` (value: `unknown`) |
+| 16.3 | --json status | ✅ PASS | Valid JSON output |
+| 16.3 | --json doctor | ✅ PASS | Valid JSON output |
+| 16.4 | Global --json flag | ⚠️ WARN | `autoinfo --json status` not recognized as global flag; status output in plain text |
+
+**Q16 Summary:** 4 PASS, 0 FAIL, 0 SKIP, 1 WARN
+
+---
+
+## Q17: CLI Edge Cases
+
+| # | Scenario | Result | Detail |
+|---|----------|--------|--------|
+| 17.1 | Missing --domain | ✅ PASS | "Either --domain or --all must be provided." |
+| 17.2 | Unknown flag | ✅ PASS | Click-style "No such option" error |
+| 17.3 | Commands without config | ✅ PASS | "No configuration found. Run 'autoinfo init' first." |
+| 17.4 | Invalid --format | ✅ PASS | "Unsupported export format: 'invalid'. Supported: markdown, json, sqlite, pdf, rss, csv, graphml, agent, bundle" |
+| 17.5 | Missing subcommand | ✅ PASS | Shows help with list/add/remove/test |
+| 17.6 | Empty keywords | ✅ PASS | "At least one keyword is required." |
+| 17.7 | Multi-value flags | ⚠️ WARN | `--domains A --domains B` didn't produce JSON output (empty KB), but no crash |
+| 17.8 | Special chars | ✅ PASS | Domain `test-domain_special-123` added successfully |
+| 17.9 | Spaces in domain | ⚠️ WARN | Domain `My Custom Domain` was accepted (plan expected rejection) |
+
+**Q17 Summary:** 7 PASS, 0 FAIL, 0 SKIP, 2 WARN
+
+---
+
+## Q18: Trace CLI
+
+| # | Scenario | Result | Detail |
+|---|----------|--------|--------|
+| 18.1 | Trace collection stage | ✅ PASS | Shows `Trace: <uuid>`, "No pipeline events found" (no logged pipeline events for the trace_id) |
+| 18.2 | Unknown trace_id | ✅ PASS | `Trace: 0000...`, "No pipeline events found" — friendly, no crash, exit 0 |
+
+**Q18 Summary:** 2 PASS, 0 FAIL, 0 SKIP, 0 WARN
+
+---
+
+## Overall Totals
+
+| Metric | Count |
+|--------|-------|
+| Total scenarios | 50 |
+| ✅ PASS | 34 |
+| ❌ FAIL | 2 |
+| ⏭️ SKIP | 6 |
+| ⚠️ WARN | 8 |
+| **Pass rate (non-skipped)** | **77.3%** (34/44) |
+
+### Key Failures Explained
+
+1. **12.2 Add schedule** — `weekly-ivf` already exists because it's pre-populated by the `medical-research` demo. This is a test data collision, not a CLI defect.
+2. **12.4 Run schedules** — Collect module fails with `ImportError: cannot import name 'etree'` from `lxml`. This is an environment/infrastructure issue (missing XML C library), not a CLI bug.
+
+### Warnings Summary
+
+| Warning | Issue |
+|---------|-------|
+| 10.6 Empty text | Returns JSON with `unknown` level instead of user-friendly error |
+| 11.4, 13.5, 14.2 --json flags | Several subcommands don't support `--json` |
+| 12.9 Add delivery | Validation plan flags are wrong (`--name`/`--expression`/`--output-type` → actual: `--schedule`/`--output`) |
+| 16.4 Global --json | `--json` before subcommand not recognized as global flag |
+| 17.7 Multi-value flags | No JSON output from empty KB |
+| 17.9 Spaces in domain | Domain names with spaces were accepted (plan expected rejection) |

--- a/docs/autoinfo-validation-master-plan/scenarios/enduser-deliverable.yaml
+++ b/docs/autoinfo-validation-master-plan/scenarios/enduser-deliverable.yaml
@@ -1,0 +1,234 @@
+# =============================================================================
+# Scenario: enduser-deliverable
+# Description: Full end-user validation with real API/LLM calls producing
+#   a deliverable ZIP with raw data + processed reports
+# Tags: enduser, real-api, real-llm, deliverable, regression
+# Prerequisites: AUTOINFO_LLM_API_KEY set to a working OpenCode Go key
+# =============================================================================
+
+- name: "Setup — clean project"
+  tool: bash
+  command: |
+    TEST_DIR="/tmp/test-enduser-final"
+    rm -rf "$TEST_DIR" && mkdir -p "$TEST_DIR"
+    cd "$TEST_DIR"
+    autoinfo init --demo medical-research 2>&1
+    echo "EXIT=$?"
+  expected:
+    exit_code: 0
+
+- name: "Add ai-commercial domain"
+  tool: bash
+  command: |
+    cd /tmp/test-enduser-final
+    autoinfo init --demo ai-commercial 2>&1
+    echo "EXIT=$?"
+  expected:
+    exit_code: 0
+
+- name: "Phase 1.1 — Real PubMed collection"
+  tool: bash
+  command: |
+    cd /tmp/test-enduser-final
+    autoinfo collect --domain medical-research --topic "IVF PGT-A" --source pubmed --limit 5 2>&1
+    echo "EXIT=$?"
+  expected:
+    exit_code: 0
+
+- name: "Phase 1.2 — Real TechCrunch RSS collection"
+  tool: bash
+  command: |
+    cd /tmp/test-enduser-final
+    autoinfo collect --domain ai-commercial --source techcrunch --limit 5 2>&1
+    echo "EXIT=$?"
+  expected:
+    exit_code: 0
+
+- name: "Phase 2.1 — Real LLM process (medical-research)"
+  tool: bash
+  command: |
+    cd /tmp/test-enduser-final
+    autoinfo process --domain medical-research 2>&1
+    echo "EXIT=$?"
+  expected:
+    exit_code: 0
+
+- name: "Phase 2.2 — Real LLM process (ai-commercial)"
+  tool: bash
+  command: |
+    cd /tmp/test-enduser-final
+    autoinfo process --domain ai-commercial 2>&1
+    echo "EXIT=$?"
+  expected:
+    exit_code: 0
+
+- name: "Phase 2.3 — Verify KB entries have non-empty summaries"
+  tool: python
+  command: |
+    import sys, os, json
+    os.chdir("/tmp/test-enduser-final")
+    data = json.loads(os.popen("autoinfo summaries list --domain medical-research --json 2>&1").read())
+    entries = data.get("entries", data.get("items", []))
+    total = len(entries)
+    with_summary = sum(1 for e in entries if e.get("summary", "").strip())
+    print(f"Total KB entries: {total}")
+    print(f"With non-empty summary: {with_summary}")
+    if total > 0:
+        print(f"Summary coverage: {with_summary/total*100:.0f}%")
+    assert with_summary > 0, "No summaries generated"
+    print("PASS:KB_ENTRIES_WITH_SUMMARIES")
+  expected:
+    exit_code: 0
+    stdout_contains:
+      - "PASS:KB_ENTRIES_WITH_SUMMARIES"
+
+- name: "Phase 3.1 — Generate Digest"
+  tool: bash
+  command: |
+    cd /tmp/test-enduser-final
+    autoinfo output digest --domain medical-research --period monthly 2>&1
+    echo "EXIT=$?"
+  expected:
+    exit_code: 0
+
+- name: "Phase 3.2 — Generate Report (researcher)"
+  tool: bash
+  command: |
+    cd /tmp/test-enduser-final
+    autoinfo output report --domain medical-research --audience researcher --format markdown 2>&1
+    echo "EXIT=$?"
+  expected:
+    exit_code: 0
+
+- name: "Phase 3.3 — Generate Report (executive)"
+  tool: bash
+  command: |
+    cd /tmp/test-enduser-final
+    autoinfo output report --domain ai-commercial --audience executive --format markdown 2>&1
+    echo "EXIT=$?"
+  expected:
+    exit_code: 0
+
+- name: "Phase 3.4 — Generate Report (investor)"
+  tool: bash
+  command: |
+    cd /tmp/test-enduser-final
+    autoinfo output report --domain ai-commercial --audience investor --format markdown 2>&1
+    echo "EXIT=$?"
+  expected:
+    exit_code: 0
+
+- name: "Phase 3.5 — Tutorial"
+  tool: bash
+  command: |
+    cd /tmp/test-enduser-final
+    autoinfo output tutorial --domain medical-research --audience researcher --format markdown 2>&1
+    echo "EXIT=$?"
+  expected:
+    exit_code: 0
+
+- name: "Phase 3.6 — Export formats"
+  tool: bash
+  command: |
+    cd /tmp/test-enduser-final
+    autoinfo output export --domain medical-research --format json 2>&1
+    echo "---"
+    autoinfo output export --domain ai-commercial --format json 2>&1
+    echo "---"
+    autoinfo output export --domain medical-research --format csv 2>&1
+    echo "EXIT=$?"
+  expected:
+    exit_code: 0
+
+- name: "Phase 4.1 — Cross-domain report"
+  tool: bash
+  command: |
+    cd /tmp/test-enduser-final
+    autoinfo output report --domains medical-research,ai-commercial --audience executive --format markdown 2>&1
+    echo "EXIT=$?"
+  expected:
+    exit_code: 0
+
+- name: "Phase 5.1 — Assemble deliverable ZIP"
+  tool: bash
+  command: |
+    cd /tmp/test-enduser-final
+    D="/tmp/autoinfo-enduser-deliverable"
+    rm -rf "$D" && mkdir -p "$D"/{01-raw-data,02-kb-entries,03-reports,04-digests}
+    for domain in medical-research ai-commercial; do
+      src="collections/$domain"
+      if [ -d "$src" ]; then
+        for f in $(find "$src" -name "*.json" ! -name "_runs.json" 2>/dev/null | head -20); do
+          title=$(python3 -c "import json; d=json.load(open('$f')); print(d.get('title','?')[:80])" 2>/dev/null)
+          echo "  [$domain] $title" >> "$D/01-raw-data/$domain.txt"
+        done
+      fi
+      kb="knowledge/$domain/01-Raw"
+      if [ -d "$kb" ]; then
+        cp "$kb"/*/*.md "$D/02-kb-entries/" 2>/dev/null
+      fi
+    done
+    find outputs -name "*.md" -o -name "*.json" 2>/dev/null | while read f; do
+      cp "$f" "$D/03-reports/" 2>/dev/null
+    done
+    find outputs -name "*digest*" 2>/dev/null | while read f; do
+      cp "$f" "$D/04-digests/" 2>/dev/null
+    done
+    cd /tmp && rm -f autoinfo-enduser-deliverable.zip
+    zip -r autoinfo-enduser-deliverable.zip "$(basename "$D")" 2>&1 | tail -3
+    echo "ZIP: /tmp/autoinfo-enduser-deliverable.zip ($(du -sh "$D" | cut -f1), $(find "$D" -type f | wc -l) files)"
+    echo "PASS:DELIVERABLE_CREATED"
+  expected:
+    exit_code: 0
+    stdout_contains:
+      - "PASS:DELIVERABLE_CREATED"
+
+- name: "Phase 6.1 — Verify raw data exists"
+  tool: bash
+  command: |
+    D="/tmp/autoinfo-enduser-deliverable"
+    n=$(find "$D/01-raw-data" -type f | wc -l)
+    echo "Raw data files: $n"
+    [ "$n" -ge 2 ] && echo "PASS:RAW_DATA_EXISTS" || echo "FAIL:RAW_DATA_TOO_FEW"
+  expected:
+    exit_code: 0
+    stdout_contains:
+      - "PASS:RAW_DATA_EXISTS"
+
+- name: "Phase 6.2 — Verify KB entries exist"
+  tool: bash
+  command: |
+    D="/tmp/autoinfo-enduser-deliverable"
+    n=$(find "$D/02-kb-entries" -type f 2>/dev/null | wc -l)
+    echo "KB entries: $n"
+    [ "$n" -ge 3 ] && echo "PASS:KB_ENTRIES_EXIST" || echo "WARN:KB_ENTRIES_FEW"
+    s=$(grep -l "^summary:" "$D/02-kb-entries"/*.md 2>/dev/null | wc -l)
+    ns=$(grep -L "^summary: ''" "$D/02-kb-entries"/*.md 2>/dev/null | wc -l)
+    echo "With summary field: $s"
+    echo "Non-empty summaries: $((s > 0 ? ns : 0))"
+  expected:
+    exit_code: 0
+    stdout_contains:
+      - "PASS:KB_ENTRIES_EXIST"
+
+- name: "Phase 6.3 — Verify reports exist"
+  tool: bash
+  command: |
+    D="/tmp/autoinfo-enduser-deliverable"
+    n=$(find "$D/03-reports" -type f 2>/dev/null | wc -l)
+    echo "Report files: $n"
+    [ "$n" -ge 1 ] && echo "PASS:REPORTS_EXIST" || echo "FAIL:NO_REPORTS"
+  expected:
+    exit_code: 0
+    stdout_contains:
+      - "PASS:REPORTS_EXIST"
+
+- name: "Phase 6.4 — Verify ZIP integrity"
+  tool: bash
+  command: |
+    unzip -t /tmp/autoinfo-enduser-deliverable.zip 2>&1 | tail -3
+    echo "PASS:ZIP_VALID"
+  expected:
+    exit_code: 0
+    stdout_contains:
+      - "PASS:ZIP_VALID"

--- a/tests/run_q2b_collector_tests.py
+++ b/tests/run_q2b_collector_tests.py
@@ -1,0 +1,879 @@
+#!/usr/bin/env python3
+"""
+Q2b Collector Validation — 12 New Collectors (Happy Path)
+
+Tests each of the 12 new collectors (introduced in v1.8) for:
+  1. Basic instantiation
+  2. requires_key() check (if defined)
+  3. Mock happy-path collection with mock httpx transport
+
+Each collector is tested independently.  Report at the end shows
+per-collector PASS/FAIL/SKIP and overall counts.
+"""
+
+import json
+import os
+import sys
+import uuid
+import traceback
+from typing import Any
+
+import httpx
+
+# Ensure we can import from src
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from autoinfo.models import Item
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PASS, FAIL, SKIP = "PASS", "FAIL", "SKIP"
+
+results: list[dict] = []
+
+
+def test(name: str, fn):
+    """Run a named test and record result."""
+    try:
+        fn()
+        results.append({"name": name, "result": PASS})
+        print(f"  ✅ {name}")
+    except Exception as e:
+        results.append({"name": name, "result": FAIL, "error": str(e)})
+        print(f"  ❌ {name}: {e}")
+        traceback.print_exc()
+
+
+def assert_eq(a, b, msg=""):
+    if a != b:
+        raise AssertionError(f"{msg}: expected {b!r}, got {a!r}")
+
+
+def assert_in(item, container, msg=""):
+    if item not in container:
+        raise AssertionError(f"{msg}: {item!r} not in {container!r}")
+
+
+# ---------------------------------------------------------------------------
+# 1. AP API (ap_api) — needs api_key
+# ---------------------------------------------------------------------------
+
+def test_ap_api():
+    print("\n--- 1. AP API (ap_api) ---")
+
+    # 1a. Instantiation
+    from autoinfo.collectors.ap_api import APAPIHandler
+
+    handler = APAPIHandler(api_key="test-ap-key-12345")
+    assert handler.api_key == "test-ap-key-12345"
+
+    # 1b. requires_key()
+    assert APAPIHandler.requires_key() is True
+
+    # 1c. Mock happy-path collection
+
+
+
+# AP API standalone test functions ---------------------------------------
+
+def _ap_instantiation():
+    from autoinfo.collectors.ap_api import APAPIHandler
+    h = APAPIHandler(api_key="test-key")
+    assert h.api_key == "test-key"
+    h2 = APAPIHandler()
+    assert h2.api_key == ""
+
+
+def _ap_requires_key():
+    from autoinfo.collectors.ap_api import APAPIHandler
+    assert APAPIHandler.requires_key() is True
+
+
+def _ap_mock():
+    from autoinfo.collectors.ap_api import APAPIHandler
+
+    def mock_handler(request):
+        data = {
+            "data": {
+                "items": [
+                    {
+                        "uri": "ap://article/001",
+                        "headline": "Global Markets Rally on Tech Earnings",
+                        "body": "Stock markets surged worldwide following strong earnings...",
+                        "byline": "By John Smith",
+                        "published": "2024-06-15T10:30:00Z",
+                        "section": "Business",
+                        "language": "en",
+                        "source": "Associated Press",
+                    }
+                ]
+            }
+        }
+        return httpx.Response(200, json=data, request=request)
+
+    transport = httpx.MockTransport(mock_handler)
+    with httpx.Client(transport=transport) as client:
+        import autoinfo.collectors.ap_api as mod
+        orig = mod.httpx.get
+        mod.httpx.get = client.get
+        try:
+            h = APAPIHandler(api_key="fake-ap-key")
+            articles = h.fetch(limit=10)
+            items = [h.to_item(a) for a in articles]
+            assert_eq(len(items), 1)
+            assert_eq(items[0].source_platform, "ap_api")
+            assert_eq(items[0].title, "Global Markets Rally on Tech Earnings")
+            assert "Stock markets" in items[0].content
+        finally:
+            mod.httpx.get = orig
+
+
+test("ap_api: instantiation", _ap_instantiation)
+test("ap_api: requires_key", _ap_requires_key)
+test("ap_api: mock collection", _ap_mock)
+
+
+# ---------------------------------------------------------------------------
+# 2. Apple Podcasts (apple_podcasts) — no key needed
+# ---------------------------------------------------------------------------
+
+def _test_apple_instantiation():
+    from autoinfo.collectors.apple_podcasts import ApplePodcastsHandler
+    h = ApplePodcastsHandler()
+    assert h is not None
+    h2 = ApplePodcastsHandler({"term": "AI"})
+    assert h2.config.get("term") == "AI"
+
+
+def _test_apple_mock():
+    from autoinfo.collectors.apple_podcasts import ApplePodcastsHandler
+
+    def mock_handler(request):
+        data = {
+            "resultCount": 1,
+            "results": [
+                {
+                    "trackId": 123456789,
+                    "trackName": "AI Frontiers Podcast",
+                    "description": "Weekly podcast exploring the latest in AI.",
+                    "artistName": "TechMedia Inc.",
+                    "feedUrl": "https://feeds.example.com/ai-frontiers",
+                    "releaseDate": "2024-01-15T00:00:00Z",
+                    "collectionViewUrl": "https://podcasts.apple.com/podcast/id123456789",
+                    "primaryGenreName": "Technology",
+                    "artworkUrl600": "https://example.com/artwork.jpg",
+                    "trackCount": 50,
+                    "country": "USA",
+                    "genres": ["Technology", "Science"],
+                }
+            ],
+        }
+        return httpx.Response(200, json=data, request=request)
+
+    transport = httpx.MockTransport(mock_handler)
+    with httpx.Client(transport=transport) as client:
+        import autoinfo.collectors.apple_podcasts as mod
+        orig = mod.httpx.get
+        mod.httpx.get = client.get
+        try:
+            h = ApplePodcastsHandler({"term": "AI podcast"})
+            shows = h.fetch(term="AI podcast", limit=10)
+            items = [h.to_item(s) for s in shows]
+            assert_eq(len(items), 1)
+            assert_eq(items[0].source_platform, "apple_podcasts")
+            assert_eq(items[0].title, "AI Frontiers Podcast")
+            assert items[0].raw_data.get("feed_url") == "https://feeds.example.com/ai-frontiers"
+        finally:
+            mod.httpx.get = orig
+
+
+test("apple_podcasts: instantiation", _test_apple_instantiation)
+test("apple_podcasts: mock collection", _test_apple_mock)
+
+
+# ---------------------------------------------------------------------------
+# 3. Bilibili (bilibili) — no key needed
+# ---------------------------------------------------------------------------
+
+def _test_bilibili_instantiation():
+    from autoinfo.collectors.bilibili import BilibiliHandler
+    h = BilibiliHandler()
+    assert h is not None
+    h2 = BilibiliHandler({"query": "大模型"})
+    assert h2.query == "大模型"
+
+
+def _test_bilibili_mock():
+    from autoinfo.collectors.bilibili import BilibiliHandler
+
+    def mock_handler(request):
+        data = {
+            "code": 0,
+            "message": "success",
+            "data": {
+                "result": {
+                    "video": [
+                        {
+                            "aid": 123456789,
+                            "bvid": "BV1xx411c7mD",
+                            "title": "大模型训练技术详解",
+                            "description": "深入讲解大规模语言模型的训练方法...",
+                            "author": "AI技术分享",
+                            "created": 1700000000,
+                            "pic": "https://example.com/thumb.jpg",
+                            "stat": {"view": 50000},
+                        }
+                    ]
+                }
+            },
+        }
+        return httpx.Response(200, json=data, request=request)
+
+    transport = httpx.MockTransport(mock_handler)
+    with httpx.Client(transport=transport) as client:
+        import autoinfo.collectors.bilibili as mod
+        orig = mod.httpx.get
+        mod.httpx.get = client.get
+        try:
+            h = BilibiliHandler({"query": "大模型"})
+            videos = h.fetch(limit=10)
+            items = [h.to_item(v) for v in videos]
+            assert_eq(len(items), 1)
+            assert_eq(items[0].source_platform, "bilibili")
+            assert "大模型" in items[0].title
+            assert items[0].raw_data.get("bvid") == "BV1xx411c7mD"
+        finally:
+            mod.httpx.get = orig
+
+
+test("bilibili: instantiation", _test_bilibili_instantiation)
+test("bilibili: mock collection", _test_bilibili_mock)
+
+
+# ---------------------------------------------------------------------------
+# 4. DBLP (dblp) — no key needed
+# ---------------------------------------------------------------------------
+
+def _test_dblp_instantiation():
+    from autoinfo.collectors.dblp import DBLPHandler
+    h = DBLPHandler()
+    assert h is not None
+    assert h.source_name == "dblp"
+
+
+def _test_dblp_mock():
+    from autoinfo.collectors.dblp import DBLPHandler
+
+    def mock_handler(request):
+        data = {
+            "result": {
+                "hits": {
+                    "@total": "2",
+                    "hit": [
+                        {
+                            "@score": "1.0",
+                            "@id": "https://dblp.org/rec/conf/nips/Doe2024",
+                            "info": {
+                                "title": "Neural Network Optimization",
+                                "doi": "10.1234/nn2024",
+                                "authors": {"author": ["John Smith", "Jane Doe"]},
+                                "year": "2024",
+                                "venue": "NeurIPS 2024",
+                            },
+                        },
+                        {
+                            "@score": "0.8",
+                            "@id": "https://dblp.org/rec/journals/ai/Lee2023",
+                            "info": {
+                                "title": "Symbolic Reasoning in LLMs",
+                                "doi": "",
+                                "authors": {"author": "Min Lee"},
+                                "year": "2023",
+                                "venue": "Artificial Intelligence",
+                            },
+                        },
+                    ],
+                }
+            }
+        }
+        return httpx.Response(200, json=data, request=request)
+
+    transport = httpx.MockTransport(mock_handler)
+    with httpx.Client(transport=transport) as client:
+        import autoinfo.collectors.dblp as mod
+        orig = mod.httpx.get
+        mod.httpx.get = client.get
+        try:
+            h = DBLPHandler()
+            pubs = h.fetch("machine learning", limit=10)
+            items = [h.to_item(p) for p in pubs]
+            assert_eq(len(items), 2)
+            assert_eq(items[0].source_platform, "dblp")
+            assert_eq(items[0].title, "Neural Network Optimization")
+            assert items[0].raw_data.get("venue") == "NeurIPS 2024"
+        finally:
+            mod.httpx.get = orig
+
+
+test("dblp: instantiation", _test_dblp_instantiation)
+test("dblp: mock collection", _test_dblp_mock)
+
+
+# ---------------------------------------------------------------------------
+# 5. NYT (nyt) — needs api_key
+# ---------------------------------------------------------------------------
+
+def _test_nyt_instantiation():
+    from autoinfo.collectors.nyt import NYTHandler
+    h = NYTHandler()
+    assert h is not None
+    h2 = NYTHandler({"api_key": "test-key", "query": "AI"})
+    assert h2.api_key == "test-key"
+
+
+def _test_nyt_mock():
+    from autoinfo.collectors.nyt import NYTHandler
+
+    def mock_handler(request):
+        data = {
+            "response": {
+                "docs": [
+                    {
+                        "_id": "nyt://article/001",
+                        "headline": {"main": "AI Startups Raise Record Funding"},
+                        "abstract": "Venture capital investment in AI startups reached...",
+                        "section_name": "Technology",
+                        "subsection_name": "Startups",
+                        "pub_date": "2024-06-15T09:00:00Z",
+                        "web_url": "https://www.nytimes.com/2024/06/15/technology/ai-funding.html",
+                        "byline": {"original": "By Jane Reporter"},
+                        "word_count": 850,
+                        "document_type": "article",
+                    }
+                ]
+            }
+        }
+        return httpx.Response(200, json=data, request=request)
+
+    transport = httpx.MockTransport(mock_handler)
+    with httpx.Client(transport=transport) as client:
+        import autoinfo.collectors.nyt as mod
+        orig = mod.httpx.get
+        mod.httpx.get = client.get
+        try:
+            h = NYTHandler({"api_key": "fake-nyt-key", "query": "AI funding"})
+            articles = h.fetch(limit=10)
+            items = [h.to_item(a) for a in articles]
+            assert_eq(len(items), 1)
+            assert_eq(items[0].source_platform, "nyt")
+            assert_eq(items[0].title, "AI Startups Raise Record Funding")
+        finally:
+            mod.httpx.get = orig
+
+
+test("nyt: instantiation", _test_nyt_instantiation)
+test("nyt: mock collection", _test_nyt_mock)
+
+
+# ---------------------------------------------------------------------------
+# 6. OpenAlex (openalex) — no key needed
+# ---------------------------------------------------------------------------
+
+def _test_openalex_instantiation():
+    from autoinfo.collectors.openalex import OpenAlexHandler
+    h = OpenAlexHandler()
+    assert h is not None
+    h2 = OpenAlexHandler({"query": "CRISPR"})
+    assert h2.config.get("query") == "CRISPR"
+
+
+def _test_openalex_mock():
+    from autoinfo.collectors.openalex import OpenAlexHandler
+
+    def mock_handler(request):
+        data = {
+            "results": [
+                {
+                    "id": "https://openalex.org/W4200000001",
+                    "title": "Advances in CRISPR Gene Editing",
+                    "abstract_inverted_index": {"crispr": [0], "gene": [1], "editing": [2]},
+                    "authorships": [{"author": {"display_name": "Jane Doe"}}],
+                    "cited_by_count": 42,
+                    "publication_date": "2024-06-15",
+                },
+                {
+                    "id": "https://openalex.org/W4200000002",
+                    "title": "Machine Learning for Protein Folding",
+                    "abstract_inverted_index": None,
+                    "authorships": [],
+                    "cited_by_count": 0,
+                    "publication_date": "2023-01-01",
+                },
+            ],
+            "meta": {"count": 2},
+        }
+        return httpx.Response(200, json=data, request=request)
+
+    transport = httpx.MockTransport(mock_handler)
+    with httpx.Client(transport=transport) as client:
+        import autoinfo.collectors.openalex as mod
+        orig = mod.httpx.get
+        mod.httpx.get = client.get
+        try:
+            h = OpenAlexHandler({"query": "CRISPR"})
+            articles = h.fetch(limit=5)
+            items = [h.to_item(a) for a in articles]
+            assert_eq(len(items), 2)
+            assert_eq(items[0].source_platform, "openalex")
+            assert_eq(items[0].title, "Advances in CRISPR Gene Editing")
+            assert "crispr" in items[0].content
+        finally:
+            mod.httpx.get = orig
+
+
+test("openalex: instantiation", _test_openalex_instantiation)
+test("openalex: mock collection", _test_openalex_mock)
+
+
+# ---------------------------------------------------------------------------
+# 7. Reddit (reddit) — no key needed for public access (OAuth2)
+# ---------------------------------------------------------------------------
+
+def _test_reddit_instantiation():
+    from autoinfo.collectors.reddit import RedditHandler
+    h = RedditHandler({
+        "client_id": "test", "client_secret": "test",
+        "user_agent": "AutoInfo/1.0", "subreddits": ["MachineLearning"],
+    })
+    assert h is not None
+    assert h.subreddits == ["MachineLearning"]
+
+
+def _test_reddit_mock():
+    from autoinfo.collectors.reddit import RedditHandler
+    token_called = []
+
+    def mock_handler(request):
+        if "/api/v1/access_token" in str(request.url):
+            token_called.append(True)
+            return httpx.Response(200, json={
+                "access_token": "fake-reddit-token-xxxx",
+                "token_type": "bearer",
+                "expires_in": 3600,
+            }, request=request)
+        data = {
+            "data": {
+                "children": [
+                    {
+                        "data": {
+                            "name": "t3_abc123",
+                            "title": "Latest advances in reinforcement learning",
+                            "selftext": "Researchers at DeepMind have achieved...",
+                            "author": "ml_researcher",
+                            "subreddit": "MachineLearning",
+                            "score": 250,
+                            "num_comments": 45,
+                            "created_utc": 1700000000.0,
+                            "url": "https://reddit.com/r/MachineLearning/comments/abc123",
+                        }
+                    }
+                ]
+            }
+        }
+        return httpx.Response(200, json=data, request=request)
+
+    transport = httpx.MockTransport(mock_handler)
+    with httpx.Client(transport=transport) as client:
+        import autoinfo.collectors.reddit as mod
+        orig_post = mod.httpx.post
+        orig_get = mod.httpx.get
+        mod.httpx.post = client.post
+        mod.httpx.get = client.get
+        try:
+            h = RedditHandler({
+                "client_id": "fake-client", "client_secret": "fake-secret",
+                "user_agent": "AutoInfo/1.0", "subreddits": ["MachineLearning"],
+            })
+            posts = h.fetch(query="reinforcement learning", limit=5)
+            items = [h.to_item(p) for p in posts]
+            assert_eq(len(items), 1)
+            assert_eq(items[0].source_platform, "reddit")
+            assert_eq(items[0].title, "Latest advances in reinforcement learning")
+            assert len(token_called) == 1, "OAuth2 token should have been requested"
+        finally:
+            mod.httpx.post = orig_post
+            mod.httpx.get = orig_get
+
+
+test("reddit: instantiation", _test_reddit_instantiation)
+test("reddit: mock collection", _test_reddit_mock)
+
+
+# ---------------------------------------------------------------------------
+# 8. Reuters MCP (reuters_mcp) — needs api_key
+# ---------------------------------------------------------------------------
+
+def _test_reuters_instantiation():
+    from autoinfo.collectors.reuters_mcp import ReutersMCPHandler
+    from autoinfo.config import SourceConfig
+    cfg = SourceConfig(name="reuters-test", type="reuters_mcp",
+                       url="https://api.reuters.com/content/v1/search",
+                       settings={"api_key": "test-key"})
+    h = ReutersMCPHandler(cfg)
+    assert h is not None
+
+
+def _test_reuters_requires_key():
+    from autoinfo.collectors.reuters_mcp import ReutersMCPHandler
+    assert ReutersMCPHandler.requires_key() is True
+
+
+def _test_reuters_mock():
+    from autoinfo.collectors.reuters_mcp import ReutersMCPHandler
+    from autoinfo.config import SourceConfig
+
+    def mock_handler(request):
+        data = {
+            "data": {
+                "items": [
+                    {
+                        "id": "reuters-001",
+                        "headline": "Fed Signals Rate Cut",
+                        "body": "The Federal Reserve indicated...",
+                        "byline": "Reuters Staff",
+                        "published": "2024-06-15T08:00:00Z",
+                        "section": "Economy",
+                        "language": "en",
+                        "source": "Reuters",
+                        "url": "https://www.reuters.com/article/001",
+                    }
+                ]
+            }
+        }
+        return httpx.Response(200, json=data, request=request)
+
+    transport = httpx.MockTransport(mock_handler)
+    with httpx.Client(transport=transport) as client:
+        import autoinfo.collectors.reuters_mcp as mod
+        orig_post = mod.httpx.post
+        mod.httpx.post = client.post
+        try:
+            cfg = SourceConfig(name="reuters-test", type="reuters_mcp",
+                               url="https://api.reuters.com/content/v1/search",
+                               settings={"api_key": "fake-reuters-key"})
+            h = ReutersMCPHandler(cfg)
+            articles = h.fetch(limit=10)
+            items = [h.to_item(a) for a in articles]
+            assert_eq(len(items), 1)
+            assert_eq(items[0].source_platform, "reuters_mcp")
+            assert_eq(items[0].title, "Fed Signals Rate Cut")
+        finally:
+            mod.httpx.post = orig_post
+
+
+test("reuters_mcp: instantiation", _test_reuters_instantiation)
+test("reuters_mcp: requires_key", _test_reuters_requires_key)
+test("reuters_mcp: mock collection", _test_reuters_mock)
+
+
+# ---------------------------------------------------------------------------
+# 9. Semantic Scholar (semantic_scholar) — needs api_key
+# ---------------------------------------------------------------------------
+
+def _test_semantic_scholar_instantiation():
+    from autoinfo.collectors.semantic_scholar import SemanticScholarHandler
+    h = SemanticScholarHandler()
+    assert h is not None
+    h2 = SemanticScholarHandler(api_key="test-key")
+    assert h2.api_key == "test-key"
+
+
+def _test_semantic_scholar_mock():
+    from autoinfo.collectors.semantic_scholar import SemanticScholarHandler
+
+    def mock_handler(request):
+        data = {
+            "data": [
+                {
+                    "paperId": "s2-001",
+                    "title": "Deep Learning Survey",
+                    "abstract": "A comprehensive survey of deep learning techniques...",
+                    "authors": [{"name": "Alice Smith"}],
+                    "citationCount": 150,
+                    "publicationDate": "2024-03",
+                },
+                {
+                    "paperId": "s2-002",
+                    "title": "Transformer Architectures",
+                    "abstract": "",
+                    "authors": [],
+                    "citationCount": 0,
+                    "publicationDate": None,
+                },
+            ]
+        }
+        return httpx.Response(200, json=data, request=request)
+
+    transport = httpx.MockTransport(mock_handler)
+    with httpx.Client(transport=transport) as client:
+        import autoinfo.collectors.semantic_scholar as mod
+        orig = mod.httpx.get
+        mod.httpx.get = client.get
+        try:
+            h = SemanticScholarHandler()
+            papers = h.fetch("deep learning", limit=10)
+            items = [h.to_item(p) for p in papers]
+            assert_eq(len(items), 2)
+            assert_eq(items[0].source_platform, "semantic_scholar")
+            assert_eq(items[0].title, "Deep Learning Survey")
+        finally:
+            mod.httpx.get = orig
+
+
+test("semantic_scholar: instantiation", _test_semantic_scholar_instantiation)
+test("semantic_scholar: mock collection", _test_semantic_scholar_mock)
+
+
+# ---------------------------------------------------------------------------
+# 10. Spotify (spotify) — needs client credentials
+# ---------------------------------------------------------------------------
+
+def _test_spotify_instantiation():
+    from autoinfo.collectors.spotify import SpotifyHandler
+    h = SpotifyHandler({"client_id": "test", "client_secret": "test"})
+    assert h is not None
+    assert h.client_id == "test"
+
+
+def _test_spotify_mock():
+    from autoinfo.collectors.spotify import SpotifyHandler
+    token_called = []
+
+    def mock_handler(request):
+        if "accounts.spotify.com" in str(request.url):
+            token_called.append(True)
+            return httpx.Response(200, json={
+                "access_token": "fake-spotify-token",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            }, request=request)
+        data = {
+            "items": [
+                {
+                    "id": "ep_001",
+                    "name": "The Future of AGI",
+                    "description": "A discussion on artificial general intelligence...",
+                    "publisher": "Tech Podcasts Inc.",
+                    "release_date": "2024-06-10",
+                    "duration_ms": 2400000,
+                    "languages": ["en"],
+                    "external_urls": {"spotify": "https://open.spotify.com/episode/ep_001"},
+                    "audio_preview_url": "https://p.scdn.co/mp3-preview/abc123",
+                    "show": {
+                        "id": "show_42",
+                        "name": "Future Tech",
+                        "publisher": "Tech Podcasts Inc.",
+                        "description": "A podcast about future technology",
+                    },
+                    "explicit": False,
+                    "type": "episode",
+                }
+            ]
+        }
+        return httpx.Response(200, json=data, request=request)
+
+    transport = httpx.MockTransport(mock_handler)
+    with httpx.Client(transport=transport) as client:
+        import autoinfo.collectors.spotify as mod
+        orig_post = mod.httpx.post
+        orig_get = mod.httpx.get
+        mod.httpx.post = client.post
+        mod.httpx.get = client.get
+        try:
+            h = SpotifyHandler({
+                "client_id": "fake-sp-client", "client_secret": "fake-sp-secret",
+                "show_id": "show_42",
+            })
+            episodes = h.fetch(limit=10, show_id="show_42")
+            items = [h.to_item(e) for e in episodes]
+            assert_eq(len(items), 1)
+            assert_eq(items[0].source_platform, "spotify")
+            assert_eq(items[0].title, "The Future of AGI")
+            assert len(token_called) == 1, "OAuth2 token should have been requested"
+        finally:
+            mod.httpx.post = orig_post
+            mod.httpx.get = orig_get
+
+
+test("spotify: instantiation", _test_spotify_instantiation)
+test("spotify: mock collection", _test_spotify_mock)
+
+
+# ---------------------------------------------------------------------------
+# 11. USPTO (uspto) — no key needed
+# ---------------------------------------------------------------------------
+
+def _test_uspto_instantiation():
+    from autoinfo.collectors.uspto import USPTOHandler
+    h = USPTOHandler()
+    assert h is not None
+
+
+def _test_uspto_mock():
+    from autoinfo.collectors.uspto import USPTOHandler
+
+    def mock_handler(request):
+        data = {
+            "patents": [
+                {
+                    "patent_number": "US12000123",
+                    "patent_title": "CRISPR-based Gene Therapy Method",
+                    "patent_abstract": "A novel method for targeted gene therapy using CRISPR-Cas9...",
+                    "patent_date": "2024-05-10",
+                    "app_date": "2023-01-15",
+                    "inventors": [{"inventor_first_name": "Alice", "inventor_last_name": "Johnson"}],
+                    "assignee_organization": "GenTech Inc.",
+                    "patent_num_cited_by_us_patents": 5,
+                    "patent_num_combined_citations": 12,
+                }
+            ]
+        }
+        return httpx.Response(200, json=data, request=request)
+
+    transport = httpx.MockTransport(mock_handler)
+    with httpx.Client(transport=transport) as client:
+        import autoinfo.collectors.uspto as mod
+        orig_post = mod.httpx.post
+        mod.httpx.post = client.post
+        try:
+            h = USPTOHandler()
+            patents = h.fetch("gene therapy", limit=10)
+            items = [h.to_item(p) for p in patents]
+            assert_eq(len(items), 1)
+            assert_eq(items[0].source_platform, "uspto")
+            assert items[0].raw_data.get("patent_number") == "US12000123"
+        finally:
+            mod.httpx.post = orig_post
+
+
+test("uspto: instantiation", _test_uspto_instantiation)
+test("uspto: mock collection", _test_uspto_mock)
+
+
+# ---------------------------------------------------------------------------
+# 12. YouTube (youtube) — needs api_key
+# ---------------------------------------------------------------------------
+
+def _test_youtube_instantiation():
+    from autoinfo.collectors.youtube import YouTubeHandler
+    h = YouTubeHandler()
+    assert h is not None
+    h2 = YouTubeHandler({"api_key": "test-key", "query": "AI"})
+    assert h2.api_key == "test-key"
+
+
+def _test_youtube_requires_key():
+    from autoinfo.collectors.youtube import YouTubeHandler
+    assert YouTubeHandler.requires_key() is True
+
+
+def _test_youtube_mock():
+    from autoinfo.collectors.youtube import YouTubeHandler
+
+    def mock_handler(request):
+        data = {
+            "items": [
+                {
+                    "id": {"videoId": "dQw4w9WgXcQ"},
+                    "snippet": {
+                        "title": "Understanding Transformers in NLP",
+                        "description": "A comprehensive guide to transformer architectures...",
+                        "channelTitle": "AI Explained",
+                        "channelId": "UC_example",
+                        "publishedAt": "2024-05-20T15:00:00Z",
+                        "thumbnails": {"default": {"url": "https://img.youtube.com/vi/dQw4/default.jpg"}},
+                    },
+                }
+            ]
+        }
+        return httpx.Response(200, json=data, request=request)
+
+    transport = httpx.MockTransport(mock_handler)
+    with httpx.Client(transport=transport) as client:
+        import autoinfo.collectors.youtube as mod
+        orig = mod.httpx.get
+        mod.httpx.get = client.get
+        try:
+            h = YouTubeHandler({"api_key": "fake-yt-key", "query": "transformers NLP"})
+            videos = h.fetch(limit=10)
+            items = [h.to_item(v) for v in videos]
+            assert_eq(len(items), 1)
+            assert_eq(items[0].source_platform, "youtube")
+            assert "Transformers" in items[0].title
+        finally:
+            mod.httpx.get = orig
+
+
+test("youtube: instantiation", _test_youtube_instantiation)
+test("youtube: requires_key", _test_youtube_requires_key)
+test("youtube: mock collection", _test_youtube_mock)
+
+
+# ---------------------------------------------------------------------------
+# Summary Report
+# ---------------------------------------------------------------------------
+
+print("\n" + "=" * 72)
+print("Q2b Collector Validation — Summary Report")
+print("=" * 72)
+
+# Group by collector
+collectors = {}
+for r in results:
+    name = r["name"].split(":")[0].strip()
+    if name not in collectors:
+        collectors[name] = []
+    collectors[name].append(r)
+
+total_pass = sum(1 for r in results if r["result"] == PASS)
+total_fail = sum(1 for r in results if r["result"] == FAIL)
+total_skip = sum(1 for r in results if r["result"] == SKIP)
+
+print(f"\n{'Collector':<25} {'Instantiate':<12} {'requires_key':<14} {'Mock Collect':<14} {'Status':<10}")
+print("-" * 75)
+
+for collector_name in [
+    "ap_api", "apple_podcasts", "bilibili", "dblp", "nyt",
+    "openalex", "reddit", "reuters_mcp", "semantic_scholar",
+    "spotify", "uspto", "youtube",
+]:
+    col_results = collectors.get(collector_name, [])
+    inst = next((r for r in col_results if "instantiation" in r["name"]), None)
+    rkey = next((r for r in col_results if "requires_key" in r["name"]), None)
+    mock = next((r for r in col_results if "mock collection" in r["name"] or "mock" in r["name"]), None)
+
+    inst_r = inst["result"] if inst else "—"
+    rkey_r = rkey["result"] if rkey else "—"
+    mock_r = mock["result"] if mock else "—"
+
+    fails = [r for r in col_results if r["result"] == FAIL]
+    status = "✅ PASS" if not fails else "❌ FAIL"
+    if not col_results:
+        status = "⏭️ SKIP"
+
+    print(f"{collector_name:<25} {inst_r:<12} {rkey_r:<14} {mock_r:<14} {status:<10}")
+    if fails:
+        for f in fails:
+            print(f"  └─ Error: {f.get('error', '?')}")
+
+print("-" * 75)
+print(f"\nTotal: {len(results)} tests | ✅ PASS: {total_pass} | ❌ FAIL: {total_fail} | ⏭️ SKIP: {total_skip}")
+
+if total_fail > 0:
+    print("\n❌ OVERALL: SOME COLLECTORS FAILED")
+    sys.exit(1)
+else:
+    print("\n✅ OVERALL: ALL COLLECTORS PASSED")
+    sys.exit(0)


### PR DESCRIPTION
入库可复用的验证流程资产（一次性产物已清理/归档）:
- docs/autoinfo-validation-master-plan/part-02-cli-depth-results-q10-q18.md — Q10-Q18 CLI 深度测试结果基线
- docs/autoinfo-validation-master-plan/scenarios/enduser-deliverable.yaml — end-user 交付验证场景配置
- tests/run_q2b_collector_tests.py — Q2B collector 测试脚本