### PR TITLE
fix #210: default TTS engine to local (edge-tts) — openai endpoint unreachable in deployment

### DIFF
--- a/src/autoinfo/config.py
+++ b/src/autoinfo/config.py
@@ -426,15 +426,16 @@ class TTSConfig:
     Attributes
     ----------
     engine:
-        TTS engine to use. ``"openai"`` (default) for OpenAI TTS API,
-        ``"local"`` for edge-tts (free, offline-capable),
+        TTS engine to use. ``"local"`` (default, edge-tts, free and
+        works where api.openai.com is unreachable — #210),
+        ``"openai"`` for OpenAI TTS API,
         ``"whisper"`` for OpenAI Whisper model via TTS API.
     local_voice:
         Voice for the local engine (edge-tts).  See
         https://github.com/rany2/edge-tts#voices-list
         for available voices.  Defaults to ``"en-US-JennyNeural"``.
     """
-    engine: str = "openai"
+    engine: str = "local"
     local_voice: str = "en-US-JennyNeural"
 
 

--- a/src/autoinfo/output/__init__.py
+++ b/src/autoinfo/output/__init__.py
@@ -6774,10 +6774,10 @@ def _render_audio(
     timeout:
         HTTP request timeout in seconds (default 120).
     engine:
-        TTS engine: ``"openai"`` (default), ``"local"`` (edge-tts),
+        TTS engine: ``"local"`` (edge-tts, default), ``"openai"``,
         or ``"whisper"`` (OpenAI Whisper model via TTS API).
         When *None*, reads from the ``tts.engine`` config key, falling
-        back to ``"openai"``.
+        back to ``"local"``.
     local_voice:
         Voice name for the local engine (edge-tts).  Defaults to
         ``"en-US-JennyNeural"``.  Ignored for ``engine="openai"``
@@ -6918,7 +6918,11 @@ def _render_video_scaffold(
 def _get_tts_engine_from_config() -> str:
     """Read the ``tts.engine`` setting from the project config.
 
-    Returns ``"openai"`` when the config is missing or the key is not set.
+    Returns "local" (edge-tts) when the config is missing or the key
+    is not set.  The OpenAI TTS endpoint is unreachable from the project's
+    deployment environment (WSL has no route to api.openai.com), so the
+    local engine is the sane default (#210); "tts.engine: openai" remains
+    available for environments that can reach the endpoint.
     """
     try:
         config_path = get_config_path()
@@ -6929,7 +6933,7 @@ def _get_tts_engine_from_config() -> str:
                 return engine.engine
     except Exception:
         pass
-    return "openai"
+    return "local"
 
 
 def _render_audio_openai(


### PR DESCRIPTION
修复 #210：默认 TTS 引擎改为 local (edge-tts)。

- config.py TTSConfig.engine 默认 openai → local（根本修复：config 无 tts 段时 load_config 默认 local）
- output/__init__.py _get_tts_engine_from_config 防御默认 → local
- 显式 tts.engine: openai 仍可用（保留）
- 验证：无 config / config 无 tts 段 → local；显式 openai → openai；tests 104 passed
- Closes #210