### PR TITLE
fix #203: scenario-level per-step timeout override for long-running generation steps

### DIFF
--- a/src/autoinfo/mcp/scenarios/output-premium-products.yaml
+++ b/src/autoinfo/mcp/scenarios/output-premium-products.yaml
@@ -12,6 +12,9 @@
 # AUTOINFO_LLM_API_KEY this scenario reports unconfigured, never skipped.
 name: output-premium-products
 description: "Issue #156 — premium-briefing, magazine-digest, and enterprise-briefing generation via PRODUCT_TEMPLATES"
+# Issue #203: enterprise-briefing synthesis runs several LLM rounds and
+# exceeds the 180s default per-step timeout; raise the cap for this scenario.
+timeout: 900
 category: output
 requires_env: ["AUTOINFO_LLM_API_KEY"]
 requires_domain: ["medical-research", "general-news"]

--- a/src/autoinfo/mcp/validation.py
+++ b/src/autoinfo/mcp/validation.py
@@ -1312,6 +1312,12 @@ async def run_scenario(
             f"Unknown validation scenario: {name}. Available: {available}"
         )
 
+    # Scenario-level per-step timeout override (#203): long-running steps
+    # such as enterprise-briefing generation exceed the 180s default.
+    # Scenarios may declare a top-level ``timeout`` (seconds) to raise the
+    # cap for every step in that scenario.
+    timeout = float(scenario.get("timeout", timeout))
+
     requires_env: list[str] = scenario.get("requires_env", [])
     missing_env = [v for v in requires_env if not os.environ.get(v)]
     if missing_env:


### PR DESCRIPTION
修复 #203：enterprise-briefing 生成超时 180s/step。

- run_scenario 支持 scenario YAML 顶层 timeout 字段覆盖默认 per-step timeout
- output-premium-products.yaml 声明 timeout: 900（enterprise-briefing 多轮 LLM 合成 >180s）
- 验证：syntax OK；tests/test_validation_tools.py 91 passed
- Closes #203