### PR TITLE
fix #213: reset stale batch cursor when cache count is unchanged

### DIFF
--- a/src/autoinfo/process.py
+++ b/src/autoinfo/process.py
@@ -615,7 +615,11 @@ def run_processing(
 
         # If the cache grew (new items collected), restart from 0 so nothing
         # is missed.  If it shrank, also reset to avoid an out-of-range slice.
-        if persisted_total != total_items:
+        # Issue #213: quantity alone is a weak signal — a re-collect can
+        # produce the same count with entirely new items, leaving a stale
+        # cursor at the end that silently skips them.  A cursor past the end
+        # also indicates stale progress; reset in both cases.
+        if persisted_total != total_items or start_index >= total_items:
             start_index = 0
 
         items_slice = cached_items[start_index : start_index + batch_size]


### PR DESCRIPTION
修复 #213：batch 游标过期跳过新 items。

- process.py 重置条件扩展：start_index >= total_items 时也重置为 0
- 覆盖 re-collect 同数量全新 items 场景（数量是弱信号）
- 验证：tests/test_process.py + test_collection.py 59 passed
- Closes #213