### PR TITLE
fix #218: load_config tts default hardcodes openai — align with local (#210)

### DIFF
--- a/src/autoinfo/config.py
+++ b/src/autoinfo/config.py
@@ -782,7 +782,9 @@ def _dict_to_config(raw: dict[str, Any]) -> Config:
         ),
         cost_alerts=cost_alerts,
         tts=TTSConfig(
-            engine=str(tts_raw.get("engine", "openai")),
+            # Issue #210/#218: default must match TTSConfig.engine ("local").
+            # The dataclass default alone is bypassed by this YAML parser.
+            engine=str(tts_raw.get("engine", "local")),
             local_voice=str(tts_raw.get("local_voice", "en-US-JennyNeural")),
         ),
         output=OutputConfig(


### PR DESCRIPTION
修复 #218：#210 不完整——load_config YAML 解析路径默认仍 hardcode openai。

- config.py _dict_to_config tts_raw.get('engine', 'local')（与 TTSConfig dataclass 默认一致）
- 验证：无 tts 段 config → engine local
- Closes #218