### PR TITLE
fix #217: propagate @type marker through _build_product_output for agent D1 gate

### DIFF
--- a/scripts/validation_delivery.py
+++ b/scripts/validation_delivery.py
@@ -515,6 +515,7 @@ def _build_product_output(file_path: Path, bucket: str) -> dict[str, Any]:
     entries: list[dict[str, Any]] = []
     sections: dict[str, Any] = {}
     body: Any = ""
+    parsed: Any = None
     if fmt in ("markdown", "html"):
         try:
             body = file_path.read_text(encoding="utf-8", errors="replace")
@@ -552,7 +553,7 @@ def _build_product_output(file_path: Path, bucket: str) -> dict[str, Any]:
     key_findings = sections.get("key_findings")
     summary = sections.get("summary")
     recommendations = sections.get("recommendations")
-    return {
+    out: dict[str, Any] = {
         "product_type": product_type,
         "format": fmt or "markdown",
         "body": body,
@@ -561,6 +562,13 @@ def _build_product_output(file_path: Path, bucket: str) -> dict[str, Any]:
         "recommendations": recommendations if recommendations not in (None, "") else [],
         "entries": entries,
     }
+    # Agent JSON-LD payloads (@type: KnowledgeDigest/KnowledgeReport/
+    # KnowledgePresentation/...) carry their contract marker here so the
+    # D1 gate applies the agent-native completeness check instead of the
+    # markdown sections check (issue #217).
+    if isinstance(parsed, dict) and "@type" in parsed:
+        out["@type"] = parsed["@type"]
+    return out
 
 
 def check_authenticity(file_path: Path) -> dict[str, Any]:


### PR DESCRIPTION
修复 #217（补充）：agent JSON-LD 产物在 delivery gate 仍被拒——_build_product_output 适配时丢了 @type 标记，D1 agent 分支不触发。

- _build_product_output JSON 分支透传 parsed['@type'] 到 product_output
- 实测：KnowledgeDigest 文件 → D1/D2/D3 全 passed
- 相关测试无回归
- Closes #217