### PR TITLE
fix(validation): agent authenticity by JSON-LD @type (#217 follow-up)

### DIFF
--- a/docs/autoinfo-validation-master-plan/LOOP-LOG.md
+++ b/docs/autoinfo-validation-master-plan/LOOP-LOG.md
@@ -1,0 +1,54 @@
+# LOOP-LOG — AutoInfo validation 循环记录
+
+> 机制说明（2026-08-12 首次落实）：
+> - 每次迭代循环（打包/验证/修复）的**关键事件、根因、修复、验证结果**必须记录在此
+> - 每次迭代**开始前**必须复查本文的「坑清单」——已知坑逐条核对，避免重踩
+> - 新踩的坑当天追加到「坑清单」，格式：现象 → 根因 → 预防
+> - 用户要求：迭代要形成文档，文档要在下次迭代前被复查，否则机制流于表面
+
+---
+
+## 2026-08-12 循环（第 1-9 次打包，11 个 issue 闭环）
+
+### 打包迭代史（9 次）
+
+| # | 结果 | 失败原因 | 分类 |
+|---|------|----------|------|
+| 1-4 | 弃用（exit-0 但 zip 未核验） | config.yaml tts 段丢失 → output-ebook 走 OpenAI TTS | 环境坑 |
+| 5 | 170530.zip，4 scenarios failed | config 第 4 次丢失；premium 180s 超时；llm-gated 概率失败；data-lifecycle 游标 bug；gap=81 | 混合 |
+| 6 | 195935.zip，gap 80 | filler 产物被 D1 gate 误拒（agent JSON-LD 用 markdown sections 标准）| 深层 bug |
+| 7 | 211016.zip，gap 80 | #224 只改 quality.py，_build_product_output 丢 @type 标记，agent 判定未触发 | 修复不完整 |
+| 8 | 运行中 | 验证 #225（@type 透传）后最终打包 | — |
+
+### Issue 闭环清单（11 个）
+
+| Issue | 问题 | 根因 | 修复 | 验证 |
+|-------|------|------|------|------|
+| #203 | enterprise-briefing 180s 超时 | 两层超时：asyncio wait_for + kind:cli subprocess 180s 独立默认，只修一层无效 | scenario timeout 覆盖 + cli/http 透传 | premium ALL PASSED（第 7 次重跑）|
+| #204/#206 | gates 串行慢 / 并行崩溃 | — | 并行 + 去重 | — |
+| #208 | 12 个 MCP 工具扁平错误 | 错误 envelope 不统一 | 标准 envelope | — |
+| #210/#218 | TTS 默认 openai | **两层默认值**：TTSConfig dataclass + _dict_to_config YAML 解析硬编码，只改 dataclass 无效 | 双默认都改 local | load_config()=local；ebook ALL PASSED |
+| #213 | batch 游标过期跳过新 items | progress 只有数量无内容指纹，同数量新 items 不重置 | start_index>=total 也重置 | data-lifecycle ALL PASSED |
+| #215 | suggest_keywords LLM 空输出失败 | DeepSeek 概率空 content，无 fallback | deterministic 关键词提取 | llm-gated ALL PASSED |
+| #217 | agent JSON-LD 被 D1 误拒（105 个） | **两层**：quality.py D1 判定 + validation_delivery 适配丢 @type | D1 agent-native 检查 + @type 透传 | D1/D2/D3 passed 实测 |
+| #220 | presentation slides 空 | LLM 空 slides + 空 shell guard | KB-derived slides fallback | 6 cells 重跑全 OK |
+
+### 坑清单（迭代前必查！）
+
+1. **config.yaml 未提交修改在 checkout/并行操作时静默丢失**（WSL DrvFs，`.autoinfo/` gitignored）
+   → 关键配置立即 commit 或 /tmp 备份；打包前置 `grep -q "tts:"` 自检
+2. **`gh pr merge --delete-branch` 自动切回本地旧 main**——本地 main 落后远程（fetch 失败）时，后台任务读旧代码，修复"假阳性"
+   → 每次 merge 后确认工作树分支与 sha；后台任务启动前 `git rev-parse HEAD` + grep 修复标记
+3. **同一功能多层实现**：改一处默认/判定不够——修前 grep 所有相关层（dataclass/YAML 解析、asyncio/subprocess、gate/适配层）
+4. **后台进程读启动时的工作树**：启动后再改代码不影响已启动进程——验证进程实际加载的版本
+5. **WSL fetch/push GnuTLS 间歇失败** → 重试或 gh api 绕行；同步前确认 origin/main sha
+6. **filler 生成的产物要过 D1 才算 produced**：产物存在 ≠ matrix 计入（gate 拒绝就不算）——验证走 manifest accepted
+7. **agent JSON-LD 的 entry 字段按类型不同**：KnowledgeDigest=entries(source_url+source_platform)；KnowledgePresentation=slides(内容)+sources(来源)；KnowledgeTutorial=steps/exercises(内容)+source_entries(来源)——authenticity 必须按 @type 分支检查，不能一刀切
+8. **生成端硬编码空字段**：generate_report agent 渲染曾 `source_platform: ""` 写死（KB 数据有值但产物空）——修生成端后**必须重新生成旧产物**（已生成的不变）
+9. **_json_entries 对顶层含 _ENTRY_KEYS 交集的 dict 会整体当 entry**：KnowledgeTutorial 顶层有 title → 被误当 1 个 entry——按 @type 特判（source_entries）绕过
+
+### 复盘（为什么 9 次）
+
+- 任务固有难度低：最终只有 2 个深层 bug（agent D1 误判、TTS 双默认）+ 若干流程坑
+- 6-7 次失败是我的执行问题：① 环境坑反复踩（文档机制从未落实，坑没固化为检查项）；② 修复只修一层（未 grep 全层）；③ 验证假阳性（进程读旧代码，验证的是新代码）
+- 教训：**修复前先扫全实现层 + 验证前确认进程读的代码版本 + 新坑当天进 LOOP-LOG**

--- a/scripts/validation_delivery.py
+++ b/scripts/validation_delivery.py
@@ -599,25 +599,61 @@ def check_authenticity(file_path: Path) -> dict[str, Any]:
             "reason": "no structured source entries found in payload — nothing to verify",
         }
     problems: list[str] = []
-    for i, entry in enumerate(entries):
-        url = entry.get("source_url", "")
-        if not isinstance(url, str) or not url.strip():
-            problems.append(f"entry[{i}] missing source_url")
-        elif "example.com" in url:
-            problems.append(f"entry[{i}] placeholder source_url: {url}")
-        # source_type is required for raw collection payloads but is not
-        # part of agent JSON-LD entries (KnowledgeDigest etc. carry
-        # source_platform instead) — only require source_platform there
+    is_agent_ld = bool(parsed.get("@type")) if isinstance(parsed, dict) else False
+    if is_agent_ld and parsed.get("@type") == "KnowledgePresentation":
+        # Slides are content, not source entries; the deck's provenance
+        # lives in the top-level "sources" list (issue #217).
+        sources = parsed.get("sources") or []
+        for i, src in enumerate(sources):
+            if not isinstance(src, dict):
+                continue
+            url = src.get("source_url", "")
+            if not isinstance(url, str) or not url.strip():
+                problems.append(f"sources[{i}] missing source_url")
+        if not sources:
+            return {
+                "authenticity": "pass",
+                "reason": "presentation has no provenance sources — nothing to verify",
+            }
+    elif is_agent_ld and parsed.get("@type") == "KnowledgeTutorial":
+        # Tutorial content (steps/exercises) is authored material; its
+        # provenance lives in the top-level "source_entries" list
         # (issue #217).
-        is_agent_ld = bool(parsed.get("@type")) if isinstance(parsed, dict) else False
-        for field in (() if is_agent_ld else ("source_type", "source_platform")):
-            val = entry.get(field, "")
-            if not isinstance(val, str) or not val.strip():
-                problems.append(f"entry[{i}] missing {field}")
-        if is_agent_ld:
-            val = entry.get("source_platform", "")
-            if not isinstance(val, str) or not val.strip():
-                problems.append(f"entry[{i}] missing source_platform")
+        source_entries = parsed.get("source_entries") or []
+        for i, src in enumerate(source_entries):
+            if not isinstance(src, dict):
+                continue
+            url = src.get("source_url", "")
+            if not isinstance(url, str) or not url.strip():
+                problems.append(f"source_entries[{i}] missing source_url")
+            plat = src.get("source_platform", "")
+            if not isinstance(plat, str) or not plat.strip():
+                problems.append(f"source_entries[{i}] missing source_platform")
+        if not source_entries:
+            return {
+                "authenticity": "pass",
+                "reason": "tutorial has no provenance source_entries — nothing to verify",
+            }
+    else:
+        for i, entry in enumerate(entries):
+            url = entry.get("source_url", "")
+            if not isinstance(url, str) or not url.strip():
+                problems.append(f"entry[{i}] missing source_url")
+            elif "example.com" in url:
+                problems.append(f"entry[{i}] placeholder source_url: {url}")
+            # source_type is required for raw collection payloads but is not
+            # part of agent JSON-LD entries (KnowledgeDigest etc. carry
+            # source_platform instead) — only require source_platform there
+            # (issue #217).
+            if is_agent_ld:
+                val = entry.get("source_platform", "")
+                if not isinstance(val, str) or not val.strip():
+                    problems.append(f"entry[{i}] missing source_platform")
+            else:
+                for field in ("source_type", "source_platform"):
+                    val = entry.get(field, "")
+                    if not isinstance(val, str) or not val.strip():
+                        problems.append(f"entry[{i}] missing {field}")
     if problems:
         shown = "; ".join(problems[:6])
         if len(problems) > 6:

--- a/src/autoinfo/output/__init__.py
+++ b/src/autoinfo/output/__init__.py
@@ -3661,11 +3661,11 @@ def generate_report(
         for section in report_data.sections:
             for item in section.items:
                 agent_entries.append({
-                    "entry_id": "",
+                    "entry_id": item.get("entry_id", ""),
                     "title": item.get("title", ""),
                     "summary": item.get("summary", ""),
                     "source_url": item.get("source_url", ""),
-                    "source_platform": "",
+                    "source_platform": item.get("source_platform", ""),
                     "collected_at": item.get("date", ""),
                     "relevance_score": item.get("relevance_score", 0),
                     "tags": [],


### PR DESCRIPTION
## 问题
#225 后 C8 打包（validation-delivery-20260812-221339.zip）：gap 80→67、agent accepted 0→27，
但 78 个 agent 产物仍被 authenticity 拒，按 @type 分三种：

| @type | 内容字段 | 来源字段 | 现状 |
|---|---|---|---|
| KnowledgeDigest (digest/report) | entries | entries | report 生成端硬编码 source_platform='' → 空 |
| KnowledgePresentation | slides | sources (顶层) | 误查 slides 的 source_url |
| KnowledgeTutorial | steps/exercises | source_entries (顶层) | 误把整个 tutorial 当 entry |

## 修复
- check_authenticity 按 @type 分支：Presentation→sources、Tutorial→source_entries、Digest→entries
- generate_report agent 渲染：source_platform 从 item 读（KB 有值 rss/CrossRef/pubmed），不再硬编码空
- 13 个 report:agent 产物用修复后代码重新生成，source_platform 100% 填满
- LOOP-LOG 追加 3 条坑（#7/#8/#9）

## 验证
- /tmp/auth_probe3.py：presentation/tutorial pass；report 需重新生成（已生成）
- 新产物 source_platform: 10/10, 20/20, 22/22 filled
Refs #217