### PR TITLE
chore(gitignore): ignore validation-deliveries/ and deliverables/ artifacts (#232)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ collections/
 knowledge/
 outputs/
 
+# Validation / delivery artifacts (reproducible, not for git)
+validation-deliveries/
+deliverables/
+
 # IDE
 .idea/
 *.swp


### PR DESCRIPTION
修复 #232：.gitignore 追加 `validation-deliveries/` 与 `deliverables/`，消除 1.4GB 验证产物被误提交的风险。

- [x] .gitignore 已追加两条
- [x] `git status` 不再显示这两个目录
- [x] 未动 `handoff/` 与 `docs/archive/`（小型文本，另行决定）