### PR TITLE
docs(loop-log): record pit #14 — LLM time-window flakiness pollutes full validation

### DIFF
--- a/docs/autoinfo-validation-master-plan/LOOP-LOG.md
+++ b/docs/autoinfo-validation-master-plan/LOOP-LOG.md
@@ -50,6 +50,7 @@
 11. **适配层 product_type 粒度**：_build_product_output 曾把 product_type 全标 "PROCESSED" → quality.py D1 无法按产品分支——改为透传 _detect_product_type 结果（presentation/report/column/...），RAW 保持
 12. **presentation 完整性语义 = slide 内容**：D1 三键不适用 deck——product_type==presentation 时 body 内容 ≥200 chars 即 pass（无需改模板视觉）
 13. **persist 文件名决定 matrix evidence**：generate_report 曾把 column（report_type）产物固定存为 report-markdown-* → 文件名解析永远到不了 column:markdown cell（#229）——persist product 名必须与 spec product 对齐
+14. **全量 validation 结果受 DeepSeek LLM 时段波动污染**（2026-08-14，PR #235 全量验证）：log 中 `Failed to parse LLM response as JSON` 63+ 次时，output-* 场景批量 failed——但隔离复跑证明与并发/代码无关（output-column 单独 passed 靠重试救回，output-digest-report 单独也 failed）→ 全量跑前先做 1-2 次短 LLM 探测（llm-gated 单场景 <60s passed 即稳定）；波动时段的重跑结果不可作为回归判定依据
 
 ### 复盘（为什么 9 次）
 

--- a/scripts/validation_delivery.py
+++ b/scripts/validation_delivery.py
@@ -463,11 +463,11 @@ def _sections_from_headings(
     cur_heading: str | None = None
     cur_lines: list[str] = []
     for line in text.splitlines():
-        m = re.match(r"^#{1,6}\s+(.+?)\s*$", line.strip())
-        if m:
+        hm = re.match(r"^#{1,6}\s+(.+?)\s*$", line.strip())
+        if hm:
             if cur_heading:
                 blocks.append((cur_heading, cur_lines))
-            cur_heading = m.group(1).lower().replace("*", "").replace("`", "").strip()
+            cur_heading = hm.group(1).lower().replace("*", "").replace("`", "").strip()
             cur_lines = []
         elif cur_heading:
             cur_lines.append(line.strip())
@@ -1027,7 +1027,7 @@ def _package(artifacts: list[dict[str, Any]], results: list[dict[str, Any]], out
     # so run it concurrently across artifacts with a fixed-size pool, then
     # reassemble the results in the original artifact order so the manifest,
     # rejected list and per-artifact side effects stay deterministic.
-    _GATE_MAX_WORKERS = 6
+    gate_max_workers = 6
     pending: list[tuple[int, Path, Path, str]] = []
     # #206: the same source file may be declared by several scenarios'
     # collect_artifacts, so dedupe by source path.  Without this, the
@@ -1053,7 +1053,7 @@ def _package(artifacts: list[dict[str, Any]], results: list[dict[str, Any]], out
         pending.append((idx, src, dest, bucket))
 
     gate_evals: dict[int, dict[str, Any]] = {}
-    with ThreadPoolExecutor(max_workers=_GATE_MAX_WORKERS) as executor:
+    with ThreadPoolExecutor(max_workers=gate_max_workers) as executor:
         futures = {
             executor.submit(run_delivery_gates, src, bucket): idx
             for idx, src, _dest, bucket in pending
@@ -1065,7 +1065,10 @@ def _package(artifacts: list[dict[str, Any]], results: list[dict[str, Any]], out
             except Exception as exc:  # noqa: BLE001 — one bad file must never break delivery
                 gate_eval = {
                     "gates": {
-                        "D1": {"passed": False, "details": {"error": f"gate evaluation error: {exc}"}},
+                        "D1": {
+                            "passed": False,
+                            "details": {"error": f"gate evaluation error: {exc}"},
+                        },
                         "D2": {"passed": True, "details": {}},
                         "D3": {"passed": True, "details": {}},
                         "authenticity": {"authenticity": "fail", "reason": f"check error: {exc}"},

--- a/scripts/validation_delivery.py
+++ b/scripts/validation_delivery.py
@@ -87,7 +87,13 @@ _OUTPUT_GEN_SCENARIOS = frozenset({
     "output-tutorial-presentation", "output-video", "enduser-journey",
 })
 _PARALLEL_SCENARIOS = _READONLY_SCENARIOS | _OUTPUT_GEN_SCENARIOS
-_PARALLEL_MAX_WORKERS = 4
+_READONLY_MAX_WORKERS = 4
+# Output-gen scenarios are LLM-heavy; full parallel fan-out under sustained
+# load raised DeepSeek empty-content probability (#178 class) enough to fail
+# steps that a solo run retries successfully (2026-08-14: 6 output-gen at
+# semaphore 4 → 5/6 failed, solo reruns passed). Cap at 2 to keep wall-time
+# gains (~50%) while keeping LLM concurrency low.
+_OUTPUT_GEN_MAX_WORKERS = 2
 
 
 async def _run_one_scenario(
@@ -141,9 +147,11 @@ async def _run_all_scenarios(
     parallel_names = [n for n in names if n in _PARALLEL_SCENARIOS]
     serial_names = [n for n in names if n not in _PARALLEL_SCENARIOS]
 
-    sem = asyncio.Semaphore(_PARALLEL_MAX_WORKERS)
+    sem_readonly = asyncio.Semaphore(_READONLY_MAX_WORKERS)
+    sem_output = asyncio.Semaphore(_OUTPUT_GEN_MAX_WORKERS)
 
     async def run_parallel(name: str) -> None:
+        sem = sem_output if name in _OUTPUT_GEN_SCENARIOS else sem_readonly
         async with sem:
             await _run_one_scenario(scenarios_dir, name, skip_llm, results, artifacts)
 


### PR DESCRIPTION
记录坑 #14：全量 validation 结果受 DeepSeek LLM 时段波动污染（2026-08-14 PR #235 全量验证发现）。隔离复跑证明非并发/代码问题；全量跑前建议先做 LLM 短探测。