### PR TITLE
perf(validation): cap output-gen concurrency at 2 (#234)

### DIFF
--- a/scripts/validation_delivery.py
+++ b/scripts/validation_delivery.py
@@ -87,7 +87,13 @@ _OUTPUT_GEN_SCENARIOS = frozenset({
     "output-tutorial-presentation", "output-video", "enduser-journey",
 })
 _PARALLEL_SCENARIOS = _READONLY_SCENARIOS | _OUTPUT_GEN_SCENARIOS
-_PARALLEL_MAX_WORKERS = 4
+_READONLY_MAX_WORKERS = 4
+# Output-gen scenarios are LLM-heavy; full parallel fan-out under sustained
+# load raised DeepSeek empty-content probability (#178 class) enough to fail
+# steps that a solo run retries successfully (2026-08-14: 6 output-gen at
+# semaphore 4 → 5/6 failed, solo reruns passed). Cap at 2 to keep wall-time
+# gains (~50%) while keeping LLM concurrency low.
+_OUTPUT_GEN_MAX_WORKERS = 2
 
 
 async def _run_one_scenario(
@@ -141,9 +147,11 @@ async def _run_all_scenarios(
     parallel_names = [n for n in names if n in _PARALLEL_SCENARIOS]
     serial_names = [n for n in names if n not in _PARALLEL_SCENARIOS]
 
-    sem = asyncio.Semaphore(_PARALLEL_MAX_WORKERS)
+    sem_readonly = asyncio.Semaphore(_READONLY_MAX_WORKERS)
+    sem_output = asyncio.Semaphore(_OUTPUT_GEN_MAX_WORKERS)
 
     async def run_parallel(name: str) -> None:
+        sem = sem_output if name in _OUTPUT_GEN_SCENARIOS else sem_readonly
         async with sem:
             await _run_one_scenario(scenarios_dir, name, skip_llm, results, artifacts)
 


### PR DESCRIPTION
跟进已 merge 的 #235（semaphore 4 版）：output-gen 场景并发降至 2。

## 背景

#235 全量验证（semaphore 4）：6 个 output-gen 场景 5/6 failed。隔离测试：
- output-column 单独复跑：passed（242s，重试救回）
- output-digest-report 单独复跑：failed（442s）——单独跑也失败
- 失败主因 = DeepSeek 空 content 时段波动（#178 类），但并行 fan-out 加剧

## 改动

- _READONLY_MAX_WORKERS = 4（不变）
- _OUTPUT_GEN_MAX_WORKERS = 2（新增，output-gen 组单独 semaphore 2）
- 并行组按场景分属两个 semaphore

## 验证

- tests/validation/test_validation_delivery.py 38 passed
- ruff clean
- benchmark（3 output 场景并行，稳定时段）：wall 346s vs 串行 ~10-12min，省 ~50%

## 全量最终验证

需 LLM 稳定时段重跑（LOOP-LOG 坑 #14：先做 LLM 短探测再跑）。