### PR TITLE
fix(output): raise video render timeouts 600s -> 1200s (#237)

### DIFF
--- a/src/autoinfo/mcp/scenarios/output-video.yaml
+++ b/src/autoinfo/mcp/scenarios/output-video.yaml
@@ -11,6 +11,11 @@
 # TTS narration -> HyperFrames project scaffold -> bun render -> MP4.
 name: output-video
 description: "V1 — report format='video' via HyperFrames (HTML+GSAP -> MP4)"
+# Issue #237: HyperFrames rendering (headless Chrome + GSAP -> MP4) on this
+# box exceeds the 600s default per-step timeout; render_hyperframes also
+# defaults to 1200s now. Raise the cap so a slow-but-healthy render is not
+# killed (WSL ffmpeg environments are slower than native).
+timeout: 1200
 category: output
 requires_env: ["AUTOINFO_LLM_API_KEY"]
 requires_domain: ["medical-research"]

--- a/src/autoinfo/output/video.py
+++ b/src/autoinfo/output/video.py
@@ -540,7 +540,7 @@ def render_hyperframes(
     project_dir: str,
     output_path: str,
     quality: str = "draft",
-    timeout: float = 600,
+    timeout: float = 1200,
 ) -> str:
     """Render a HyperFrames project to MP4 via ``bun x hyperframes render``.
 


### PR DESCRIPTION
Closes #237

## Problem
output-video scenario fails deterministically: `hyperframes render ... timed out after 600 seconds` (subprocess.TimeoutExpired). HyperFrames MP4 rendering exceeds the 600s default on this box (WSL ffmpeg slower than native).

## Fix
- `render_hyperframes` default `timeout` 600 → 1200
- `output-video.yaml` gains scenario-level `timeout: 1200` (same pattern as output-premium-products `timeout: 900` from #203, supported since e402aa5)

## Verification
- tests/output/test_video_integration.py: 7 passed (1 pre-existing sandbox failure: real-render smoke requires bun+hyperframes+ffmpeg — fails identically on main)
- ruff + mypy clean on video.py

## Acceptance (issue)
- [ ] output-video passed — needs env with bun+hyperframes+ffmpeg, verified in a full run
- [x] timeout coverage in place