### PR TITLE
fix(validation): director-required scenario steps pass actor=director (#236)

### DIFF
--- a/src/autoinfo/mcp/scenarios/director-backdoor.yaml
+++ b/src/autoinfo/mcp/scenarios/director-backdoor.yaml
@@ -1,7 +1,9 @@
 # Director backdoor (plan todo T9c / T5) — demote / force-promote / wiki
 # delete are director-only.  Every non-whitelisted actor call is refused at
-# dispatch with a DIRECTOR_ONLY error envelope; the default actor ("director",
-# the first member of AUTOINFO_DIRECTOR_ACTORS) succeeds.
+# dispatch with a DIRECTOR_ONLY error envelope; the director path requires
+# an explicit actor whitelisted in AUTOINFO_DIRECTOR_ACTORS (default
+# "director").  The MCP tools declare ``actor`` as a required parameter —
+# an omitted actor is refused (dispatch defaults to "agent").
 #
 # Also pins the T5 wiki guard: soft_delete_entry on a 03-Wiki entry with a
 # non-director actor is refused (03-Wiki is append-only).
@@ -53,10 +55,11 @@ steps:
       error_code: "DIRECTOR_ONLY"
       error_actionable: true
 
-  - name: "force_promote succeeds for default director actor"
+  - name: "force_promote succeeds for director actor"
     tool: force_promote
     arguments:
       draft_id: medical-research-draft-t9-backdoor-draft
+      actor: director
     expect:
       success: true
       data_has: ["status", "draft_id", "new_path"]
@@ -81,10 +84,11 @@ steps:
       error_code: "DIRECTOR_ONLY"
       error_actionable: true
 
-  - name: "demote_kb_wiki succeeds for default director actor"
+  - name: "demote_kb_wiki succeeds for director actor"
     tool: demote_kb_wiki
     arguments:
       entry_id: medical-research-draft-t9-backdoor-draft
+      actor: director
     expect:
       success: true
       data_has: ["status", "entry_id", "new_path"]

--- a/src/autoinfo/mcp/scenarios/promotion-triggers.yaml
+++ b/src/autoinfo/mcp/scenarios/promotion-triggers.yaml
@@ -225,6 +225,7 @@ steps:
     tool: force_promote
     arguments:
       draft_id: medical-research-draft-t9-trigger-low-draft
+      actor: director
     expect:
       success: true
       data_has: ["status", "draft_id", "new_path"]

--- a/src/autoinfo/mcp/scenarios/search-tier-boost.yaml
+++ b/src/autoinfo/mcp/scenarios/search-tier-boost.yaml
@@ -77,6 +77,7 @@ steps:
     tool: force_promote
     arguments:
       draft_id: medical-research-draft-t9z-token-wiki-draft
+      actor: director
     expect:
       success: true
       data_has: ["status", "draft_id", "new_path"]

--- a/tests/validation/test_validation_coverage.py
+++ b/tests/validation/test_validation_coverage.py
@@ -20,6 +20,7 @@ import importlib.util
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -39,7 +40,7 @@ AUDIT_SCRIPT = ROOT / "scripts" / "coverage_audit.py"
 
 
 @pytest.fixture(scope="module")
-def coverage_audit():
+def coverage_audit() -> Any:
     spec = importlib.util.spec_from_file_location("coverage_audit", AUDIT_SCRIPT)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
@@ -52,7 +53,7 @@ def coverage_audit():
 # ---------------------------------------------------------------------------
 
 
-def test_kb_promote_yaml_exists_and_parses():
+def test_kb_promote_yaml_exists_and_parses() -> None:
     assert KB_PROMOTE_YAML.is_file(), "kb-promote.yaml must exist"
     data = yaml.safe_load(KB_PROMOTE_YAML.read_text(encoding="utf-8"))
     assert isinstance(data, dict)
@@ -71,7 +72,7 @@ def test_kb_promote_yaml_exists_and_parses():
     ]
 
 
-def test_kb_promote_steps_and_cleanup():
+def test_kb_promote_steps_and_cleanup() -> None:
     """kb-promote.yaml is a two-section admission matrix: [pass] eligible
     draft -> 03-Wiki with promotion_source=agent; [reject] draft whose source
     lacks source_url -> refused with no 03-Wiki row.  The cleanup routes every
@@ -108,7 +109,7 @@ def test_kb_promote_steps_and_cleanup():
     assert "CLEANED" in cleanup[0]["expect"]["stdout_has"]
 
 
-def test_kb_promote_passes_load_scenarios_validation():
+def test_kb_promote_passes_load_scenarios_validation() -> None:
     """kb-promote.yaml must be accepted by the real scenario loader."""
     sys.path.insert(0, str(ROOT / "src"))
     try:
@@ -117,6 +118,35 @@ def test_kb_promote_passes_load_scenarios_validation():
         sys.path.remove(str(ROOT / "src"))
     names = {s["name"] for s in load_scenarios()}
     assert "kb-promote" in names
+
+
+def test_director_tool_steps_carry_explicit_director_actor() -> None:
+    """Success steps for force_promote / demote_kb_wiki must pass actor.
+
+    Regression guard for #236: the director whitelist
+    (``AUTOINFO_DIRECTOR_ACTORS``, default ``director``) refuses omitted
+    actors at MCP dispatch (the default is ``agent``). Scenarios written
+    before the guard existed omitted the actor and broke once it landed
+    (director-backdoor, promotion-triggers, search-tier-boost). Success-
+    expecting director steps must declare ``actor: director`` explicitly.
+    """
+    sys.path.insert(0, str(ROOT / "src"))
+    try:
+        from autoinfo.mcp.validation import load_scenarios
+    finally:
+        sys.path.remove(str(ROOT / "src"))
+    violations = []
+    for sc in load_scenarios():
+        for i, step in enumerate(sc["steps"]):
+            if step.get("tool") not in ("force_promote", "demote_kb_wiki"):
+                continue
+            expect_success = step.get("expect", {}).get("success", True)
+            if expect_success and step.get("arguments", {}).get("actor") != "director":
+                violations.append(f"{sc['name']}[{i}] {step['name']}")
+    assert not violations, (
+        "director-only tool success steps must pass actor: director "
+        f"(#236 regression guard): {violations}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -147,7 +177,7 @@ def _write_scenario(dirpath: Path, name: str, tools: list[str]) -> Path:
     return p
 
 
-def test_covered_is_declared_intersection_with_phantom(coverage_audit, tmp_path):
+def test_covered_is_declared_intersection_with_phantom(coverage_audit: Any, tmp_path: Path) -> None:
     """A phantom scenario tool must NOT count as covering a declared tool."""
     _write_scenario(tmp_path, "good", ["alpha_tool", "beta_tool"])
     # error-boundary style: references a tool that server.py never declares
@@ -166,7 +196,7 @@ def test_covered_is_declared_intersection_with_phantom(coverage_audit, tmp_path)
     assert cov["phantom"] == ["definitely_not_a_real_tool"]
 
 
-def test_missing_is_declared_minus_covered(coverage_audit, tmp_path):
+def test_missing_is_declared_minus_covered(coverage_audit: Any, tmp_path: Path) -> None:
     """missing = declared - (declared ∩ scenario_used) = declared - scenario_used."""
     _write_scenario(tmp_path, "partial", ["alpha_tool"])
     cov = coverage_audit.compute_coverage(SERVER_SNIPPET, tmp_path)
@@ -175,7 +205,7 @@ def test_missing_is_declared_minus_covered(coverage_audit, tmp_path):
     assert set(cov["missing"]) == set(cov["declared"]) - set(cov["covered"])
 
 
-def test_full_coverage_when_all_declared_used(coverage_audit, tmp_path):
+def test_full_coverage_when_all_declared_used(coverage_audit: Any, tmp_path: Path) -> None:
     _write_scenario(
         tmp_path,
         "full",
@@ -187,7 +217,7 @@ def test_full_coverage_when_all_declared_used(coverage_audit, tmp_path):
     assert cov["phantom"] == ["definitely_not_a_real_tool"]
 
 
-def test_non_mcp_steps_do_not_count(coverage_audit, tmp_path):
+def test_non_mcp_steps_do_not_count(coverage_audit: Any, tmp_path: Path) -> None:
     """kind: cli steps reference no tool and must not enter scenario_used."""
     p = tmp_path / "mixed.yaml"
     p.write_text(
@@ -213,7 +243,7 @@ def test_non_mcp_steps_do_not_count(coverage_audit, tmp_path):
     assert cov["covered"] == ["alpha_tool"]
 
 
-def test_live_audit_prints_full_coverage():
+def test_live_audit_prints_full_coverage() -> None:
     """End-to-end: the real script against the real repo must report 145/145
     with an empty MISSING list (145 tools = 142 baseline + T5's director
     backdoor tools demote_kb_wiki/force_promote + T6's promote_pending sweep;
@@ -237,7 +267,7 @@ def test_live_audit_prints_full_coverage():
     )
 
 
-def test_live_audit_prints_regression_scenarios():
+def test_live_audit_prints_regression_scenarios() -> None:
     """The real coverage_audit.py must print 'Regression scenarios: N (issues: ...)'."""
     result = subprocess.run(
         [sys.executable, str(AUDIT_SCRIPT)],
@@ -258,7 +288,7 @@ def test_live_audit_prints_regression_scenarios():
     assert "#135" in line
 
 
-def test_compute_coverage_includes_regression_subdir(coverage_audit, tmp_path):
+def test_compute_coverage_includes_regression_subdir(coverage_audit: Any, tmp_path: Path) -> None:
     """compute_coverage with rglob scans regression/ subdirectory for tool coverage."""
     tmp_path.mkdir(parents=True, exist_ok=True)
     _write_scenario(tmp_path, "top-level", ["alpha_tool"])


### PR DESCRIPTION
Closes #236

## Root cause (isolated repro, 2026-08-14)

All three promotion scenarios fail with the SAME signature — not the g0-schema-failed reasons guessed in the issue (those drafts belong to other scenarios):

```
[FAILED] force_promote succeeds for default director actor
  detail: expected success=True, got success=False: {'success': False,
  'error': {'code': 'DIRECTOR_ONLY', 'message': "actor 'agent' not
  whitelisted in AUTOINFO_DIRECTOR_ACTORS", 'actionable': True}}
```

The director whitelist guard (landed in 994b213, after the scenarios were written) maps an **omitted** `actor` to `"agent"` at MCP dispatch (server.py) and refuses. The scenarios called `force_promote`/`demote_kb_wiki` without an actor.

- director-backdoor: 3 passed / 4 failed (2 director steps refused + 2 cascades: wiki never promoted → soft_delete on draft succeeds, demotion never ran)
- promotion-triggers: 15 passed / 1 failed (director force-bypass refused)
- search-tier-boost: 6 passed / 2 failed (director promotion refused + search-order cascade)

## Fix

Success-expecting director steps now pass `actor: director` explicitly in 3 scenario files. **No dispatch change** — omitting the actor must stay refused (the guard is deliberate; an agent must not force-promote by omission). Step names updated from "default director actor" to "director actor".

## Regression guard

`test_validation_coverage.py` gains `test_director_tool_steps_carry_explicit_director_actor` — asserts every `force_promote`/`demote_kb_wiki` success step in the scenario library carries `actor: director`. Also fixes 11 pre-existing mypy no-untyped-def errors in the file (changed-files CI would otherwise fail).

## Verification

- 3 scenarios GREEN in isolation (RED→GREEN): 7/7, 16/16, 8/8 steps
- 50 related tests pass (kb + mcp director-backdoor + validation coverage)
- ruff + mypy clean
