### PR TITLE
fix(validation): quality-gate-config scenario — use non-normalized gate names (#242)

### DIFF
--- a/src/autoinfo/mcp/scenarios/quality-gate-config.yaml
+++ b/src/autoinfo/mcp/scenarios/quality-gate-config.yaml
@@ -1,6 +1,11 @@
 # Quality gate configuration — read, mutate, verify, restore.
 # get_gate_config: test error path (gate not configured) and success path (after set).
 # set_gate_config: create a test gate, then restore to original (no gate).
+# NOTE (2026-08-14, #242): short names like "G0" are normalised to their
+# canonical long form (G0-SchemaIntegrity) via _GATE_CONFIG_KEY_MAP, so a
+# GateNotFound probe must use a gate name outside the map (Z99-NotConfigured),
+# and the set/get/cleanup round-trip uses a scratch gate (G0-TestScratch) to
+# avoid touching real G0-SchemaIntegrity configuration.
 name: quality-gate-config
 description: "Quality gate config: read, set, verify, restore"
 category: quality
@@ -11,16 +16,16 @@ steps:
     tool: get_gate_config
     arguments:
       domain: medical-research
-      gate: G0
+      gate: Z99-NotConfigured
     expect:
       success: false
       error_code: "GateNotFound"
 
-  - name: "set_gate_config creates G0 test gate"
+  - name: "set_gate_config creates G0-TestScratch test gate"
     tool: set_gate_config
     arguments:
       domain: medical-research
-      gate: G0
+      gate: G0-TestScratch
       config:
         category: soft
         action: flag
@@ -30,19 +35,19 @@ steps:
       success: true
       data_has: ["domain", "gate", "updated", "config"]
 
-  - name: "get_gate_config verifies G0 is now configured"
+  - name: "get_gate_config verifies G0-TestScratch is now configured"
     tool: get_gate_config
     arguments:
       domain: medical-research
-      gate: G0
+      gate: G0-TestScratch
     expect:
       success: true
       data_has: ["domain", "gate", "gate_type", "config"]
 
-  - name: "cleanup: remove test G0 gate from domain quality_gates"
+  - name: "cleanup: remove test G0-TestScratch gate from domain quality_gates"
     kind: cli
     tool: _cli_cleanup
-    command: "python3 -c \"from autoinfo.config import load_config, get_config_path, save_config; cp=get_config_path(); cfg=load_config(cp); [d.quality_gates.pop('G0', None) for d in cfg.domains if d.name=='medical-research']; save_config(cfg, cp); print('GATE_REMOVED')\""
+    command: "python3 -c \"from autoinfo.config import load_config, get_config_path, save_config; cp=get_config_path(); cfg=load_config(cp); [d.quality_gates.pop('G0-TestScratch', None) for d in cfg.domains if d.name=='medical-research']; save_config(cfg, cp); print('GATE_REMOVED')\""
     expect:
       exit_code: 0
       stdout_has: ["GATE_REMOVED"]


### PR DESCRIPTION
修复 #242：quality-gate-config 场景断言过时。

## 根因

`_GATE_CONFIG_KEY_MAP`（994b213）引入后，查询短名自动规范化到长名（`G0` → `G0-SchemaIntegrity`）。场景第一步查 `G0` 期望 GateNotFound，但 G0-SchemaIntegrity 是真实配置的 gate → 规范化命中 → success=True，断言失败。

## 改动

- GateNotFound 探测改用 `Z99-NotConfigured`（不在 map，不被规范化）
- set/get/cleanup 往返改用 `G0-TestScratch`（独立 scratch gate，不碰真实 G0-SchemaIntegrity 配置）

## 验证

- 场景单独跑：8/8 步骤 passed（含 CurationGate 部分）

## 验收（对应 issue）

- [x] quality-gate-config 全步骤 passed
- [x] 场景覆盖未配置 gate 的 GateNotFound 错误路径